### PR TITLE
Added Make Script

### DIFF
--- a/tools/make
+++ b/tools/make
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# Parse the PACKAGE_PATH into an array
 arrROS_PACKAGE_PATH=(${ROS_PACKAGE_PATH//:/ })
 
+# Find the location that contains the robosub sub directory
 for i in "${arrROS_PACKAGE_PATH[@]}"
 do
     if [ -d "$i/robosub" ]; then
@@ -9,4 +11,11 @@ do
     fi
 done
 
-catkin_make
+if [ "$1" -eq "ninja" ]
+then
+    echo "Using Ninja"
+    catkin_make --use-ninja
+else
+    echo "Using Make"
+    catkin_make
+fi

--- a/tools/make
+++ b/tools/make
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+arrROS_PACKAGE_PATH=(${ROS_PACKAGE_PATH//:/ })
+
+for i in "${arrROS_PACKAGE_PATH[@]}"
+do
+    if [ -d "$i/robosub" ]; then
+        cd $i/..
+    fi
+done
+
+catkin_make

--- a/tools/make
+++ b/tools/make
@@ -2,20 +2,46 @@
 
 # Parse the PACKAGE_PATH into an array
 arrROS_PACKAGE_PATH=(${ROS_PACKAGE_PATH//:/ })
+found=0
 
 # Find the location that contains the robosub sub directory
 for i in "${arrROS_PACKAGE_PATH[@]}"
 do
+    echo "Searching $i for robosub"
+    # Found the robosub sub directory
     if [ -d "$i/robosub" ]; then
+        found=1
+        echo -e "[\033[0;32mFound\033[0m]"
         cd $i/..
+        if [ "$1" = "ninja" ]
+        then
+            # user wants to use ninja instead of make
+
+            # Check if ninja is installed
+            if [ "$(which ninja)" = "" ]; then
+                echo -e "[\033[0;31mCould not find Ninja\033[0m] Have you installed ninja-build?"
+                exit
+            fi
+
+            echo -e "[\033[0;32mUsing Ninja\033[0m]"
+            catkin_make --use-ninja
+            exit
+        else
+            # user wants to use make - default
+
+            #check if Make is installed
+            if [ "$(which make)" = "" ]; then
+                echo -e "[\033[0;31mCould not find Make\033[0m] Have you installed build-essential?"
+                exit
+            fi
+
+            echo -e "[\033[0;32mUsing Make\033[0m]"
+            catkin_make
+            exit
+        fi
     fi
 done
 
-if [ "$1" -eq "ninja" ]
-then
-    echo "Using Ninja"
-    catkin_make --use-ninja
-else
-    echo "Using Make"
-    catkin_make
+if [ "$found" -eq "0" ]; then
+    echo -e "\033[0;31mrobosub ROS package not found\033[0m. Have you sourced devel/setup.bash?"
 fi


### PR DESCRIPTION
This allows for the user to build the robosub system from any directory. Catkin_make is normally locked to be run from the parent of the src directory. Using the ROS_PACKAGE_PATH, the make script is able to work around this requirement.
