### PR TITLE
Added clean option to the make script.

### DIFF
--- a/tools/make
+++ b/tools/make
@@ -13,7 +13,20 @@ do
         found=1
         echo -e "[\033[0;32mFound\033[0m]"
         cd $i/..
-        if [ "$1" = "ninja" ]
+       
+        if [ "$1" = "clean" ]
+        then
+            if [ -n "$CATKIN_NINJA" ]; then
+                catkin_make clean
+                rm build/CMakeCache.txt
+            else
+                catkin_make clean
+                rm build/CMakeCache.txt
+            fi
+            exit
+        fi
+        
+        if [ -n "$CATKIN_NINJA" ]
         then
             # user wants to use ninja instead of make
 


### PR DESCRIPTION
Ninja users need to export the CATKIN_NINJA environment variable to some non-NULL value. Clean will also remove the CMakeCache.txt in the build folder allowing for the user to easily change build systems
