### PR TITLE
ThrottledPublisher

### DIFF
--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
         if (i-- < 0)
         {
             control_state_pub.publish(control_system->PublishControlState());
-            i = 0;
+            i = 10;
         }
         control_system->CalculateThrusterMessage();
         control_system->PublishThrusterMessage();

--- a/src/utility/ThrottledPublisher.hpp
+++ b/src/utility/ThrottledPublisher.hpp
@@ -16,7 +16,6 @@ namespace rs
                 pub = nh.advertise<msg>(topicName, queueSize);
                 this->rate = ros::Duration(1.0/hz);
                 nextPubTime = ros::Time::now();
-                ROS_INFO_STREAM("Rate: " << rate);
             }
 
             ~ThrottledPublisher()
@@ -28,7 +27,6 @@ namespace rs
                 {
                     pub.publish(message);
                     nextPubTime = ros::Time::now() + rate;
-                    ROS_INFO_STREAM("Next Pub Time: " << nextPubTime);
                 }
             }
     };

--- a/src/utility/ThrottledPublisher.hpp
+++ b/src/utility/ThrottledPublisher.hpp
@@ -1,0 +1,35 @@
+#include <ros/ros.h>
+#include <string>
+
+namespace rs
+{
+    template <class msg> class ThrottledPublisher
+    {
+        private:
+            ros::Time nextPubTime;
+            ros::Duration rate;
+            ros::Publisher pub;
+        public:
+            ThrottledPublisher(std::string  topicName, int queueSize, float hz)
+            {
+                ros::NodeHandle nh;
+                pub = nh.advertise<msg>(topicName, queueSize);
+                this->rate = ros::Duration(1.0/hz);
+                nextPubTime = ros::Time::now();
+                ROS_INFO_STREAM("Rate: " << rate);
+            }
+
+            ~ThrottledPublisher()
+            {}
+
+            void publish(msg message)
+            {
+                if (nextPubTime <= ros::Time::now())
+                {
+                    pub.publish(message);
+                    nextPubTime = ros::Time::now() + rate;
+                    ROS_INFO_STREAM("Next Pub Time: " << nextPubTime);
+                }
+            }
+    };
+};


### PR DESCRIPTION
The throttled publisher wraps a publisher and uses ros::Time to publish only after certain intervals.

Note: The ThrottledPublisher cannot publish faster than a node is running, only slower or as fast as.
