### PR TITLE
modified travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,5 @@ before_script:
   - cd ..
 
 script:
+  - catkin_make
   - catkin_make run_tests


### PR DESCRIPTION
doing only 
```
catkin_make run_tests 
```
will result in only the software necessary to run the tests to compile, this compiles everything