### PR TITLE
Travis efficiency tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
   - cd ..
 
 script:
-  - catkin_make
+  - if [ "$BUILD" == "true"] ; then catkin_make; fi
   - if [ "$TEST" == "true" ] ; then catkin_make run_tests; catkin_test_results; fi
   - if [ "$LINT" == "true" ] ; then catkin_make roslint; fi
 
@@ -55,7 +55,7 @@ matrix:
       - TEST=true
   include:
     - env: #does just the build work?
-      - JUST_BUILD=true
+      - BUILD=true
     - env: #does the linter pass?
       - LINT=true
     - env: #do all tests pass?

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
   - if [ "$LINT" == "true" ] ; then catkin_make roslint; fi
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env:
       - LINT=true


### PR DESCRIPTION
Travis now only compiles if it needs to, and fast-finishing is turned on. This allows travis to say the build passes if the only remaining builds are ones not required to pass.