### PR TITLE
Linter

### DIFF
--- a/src/CPPLINT.cfg
+++ b/src/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
 linelength=80
-filter=-legal,-whitespace/comments,-whitespace/parens,-build/namespaces,-readability/namespace,-runtime/threadsafe_fn
+filter=-legal,-whitespace/comments,-whitespace/parens,-build/namespaces,-readability/namespace,-runtime/threadsafe_fn,-readability/todo

--- a/tools/linters/cpplint_wrapper.py
+++ b/tools/linters/cpplint_wrapper.py
@@ -98,7 +98,7 @@ def CheckBraces(fn, filename, clean_lines, linenum, error):
                         itself')
         m = Match(r'^(.*)}(.*)$', line)
         if m and (not IsBlankLine(m.group(1)) or not IsBlankLine(m.group(2))):
-            if m.group(2) != ";":
+            if m.groups()[-1][-1] != ';':
                 error(filename, linenum, 'whitespace/braces', 4,
                       '} should be on a line by itself')
     pass


### PR DESCRIPTION
Found some bugs in the linter. Now ignoring Googles formatting for TODO comments. Also allowing object names for structs and enums to be on the same line as the brace.