### PR TITLE
Added Topic Data Analyzer

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -4,6 +4,7 @@ add_ros_node(pub_sub_example pub_sub.cpp)
 add_ros_node(fork_parent_example fork_parent.cpp)
 add_ros_node(fork_child_example fork_child.cpp)
 add_ros_node(param_example parameter.cpp)
+add_ros_node(data_analyzer_example data_analyzer.cpp)
 
 add_dynamic_ros_node(dynamicParameters_example DynamicParameters.cpp)
 

--- a/src/examples/data_analyzer.cpp
+++ b/src/examples/data_analyzer.cpp
@@ -11,6 +11,7 @@ void sighandler(int sig)
     ROS_INFO("max : %lf", analyzer.GetMax());
     ROS_INFO("min : %lf", analyzer.GetMin());
     ROS_INFO("avg : %lf", analyzer.GetAverage());
+    ROS_INFO("std. dev. : %lf", analyzer.GetStandardDeviation());
 
     ros::shutdown();
 }

--- a/src/examples/data_analyzer.cpp
+++ b/src/examples/data_analyzer.cpp
@@ -1,0 +1,34 @@
+#include "ros/ros.h"
+#include "std_msgs/Float32.h"
+#include "utility/test_tools.hpp"
+#include <signal.h>
+
+rs::SubscriberAnalyzer<std_msgs::Float32> analyzer;
+
+void sighandler(int sig)
+{
+    analyzer.Stop();
+    ROS_INFO("max : %lf", analyzer.GetMax());
+    ROS_INFO("min : %lf", analyzer.GetMin());
+    ROS_INFO("avg : %lf", analyzer.GetAverage());
+
+    ros::shutdown();
+}
+
+double data_extractor(const std_msgs::Float32::ConstPtr& msg)
+{
+    return msg->data;
+}
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "data_analyzer_example");
+    ros::NodeHandle n;
+
+    signal(SIGINT, sighandler);
+
+    analyzer.Init("data", &data_extractor);
+    analyzer.Start();
+
+    ros::spin();
+}

--- a/src/utility/test_tools.hpp
+++ b/src/utility/test_tools.hpp
@@ -142,7 +142,7 @@ public:
         }
 
         double min = m_data[0];
-        for (int i = 0; i < m_data.size(); ++i)
+        for (int i = 1; i < m_data.size(); ++i)
         {
             if (m_data[i] < min)
             {
@@ -162,7 +162,7 @@ public:
         }
 
         double max = m_data[0];
-        for (int i = 0; i < m_data.size(); ++i)
+        for (int i = 1; i < m_data.size(); ++i)
         {
             if (m_data[i] > max)
             {
@@ -188,6 +188,25 @@ public:
         }
 
         return sum/m_data.size();
+    }
+
+    double GetStandardDeviation()
+    {
+        if(m_data.size() == 0)
+        {
+            ROS_ERROR("no data collected, "
+                      "can't calculate standard deviation!");
+            return 0.0;
+        }
+
+        double average = GetAverage();
+        double sum = 0.0;
+        for (int i = 0; i < m_data.size(); ++i)
+        {
+            sum += pow(m_data[i] - average, 2);
+        }
+
+        return sqrt(sum/m_data.size());
     }
 
 private:


### PR DESCRIPTION
Added a class that subscribes to a topic, listens to data on the topic, then can do various calculations on the received data. Right now it just does min, max, and average, but we can add more advanced statistics later as needed.

Example use case:
For control system testing, we can subscribe to the depth topic and ensure that when we go to depth that we don't have too much overshoot by looking at the minimum depth reached. 