### PR TITLE
Histogram Tool

### DIFF
--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -1,0 +1,64 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+import rospy
+import subprocess
+import importlib
+import signal
+
+def sig_handler(signum, frame):
+    global h
+    h.plot()
+
+class Histogram():
+
+    def __init__(self, arguments):
+        self.args = arguments
+
+        # Determine type of topic we are to listen to
+        output = subprocess.Popen(['rostopic', 'type', self.args.topic], stdout=subprocess.PIPE).communicate()[0]
+        type = output.split('/')
+        i = importlib.import_module(type[0] + ".msg", type[1])
+
+        self.sub = rospy.Subscriber(self.args.topic, getattr(i, type[1][:-1]), callback=self.callback)
+        print "Subscribed to {}".format(self.args.topic)
+        self.data = []
+
+    def callback(self, msg):
+        print "Got Message"
+        self.data.append(eval('msg.' + args.attribute))
+
+    def plot(self):
+        n, bins, patches = plt.hist(self.data, 50, normed=args.normed, facecolor=args.color, alpha=args.alpha)
+
+        if args.normed:
+            plt.ylabel('Probability')
+        else:
+            plt.ylabel('Number')
+
+        plt.xlabel('Value')
+        plt.title('Histogram of {}'.format(args.topic))
+
+        plt.show()
+
+if __name__ == "__main__":
+    global h
+
+    signal.signal(signal.SIGINT, sig_handler)
+
+    rospy.init_node("Histogram", anonymous=True)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('topic', help="Topic to plot data from")
+    parser.add_argument('attribute', help="Attribute of the message to plot")
+    parser.add_argument('--normed', action='store_true', default=False, 
+                        help="Normalize the data in the Histogram")
+    parser.add_argument('--color', default='blue',
+                        help="Choose the color of the bars in the plot")
+    parser.add_argument('--alpha', type=float, default=0.75,
+                        help="Alpha of the color to use")
+    args = parser.parse_args()
+
+    h = Histogram(args)
+
+    rospy.spin()

--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -16,11 +16,13 @@ class Histogram():
         self.args = arguments
 
         # Determine type of topic we are to listen to
-        output = subprocess.Popen(['rostopic', 'type', self.args.topic], stdout=subprocess.PIPE).communicate()[0]
+        output = subprocess.Popen(['rostopic', 'type', self.args.topic],
+                                  stdout=subprocess.PIPE).communicate()[0]
         type = output.split('/')
         i = importlib.import_module(type[0] + ".msg", type[1])
 
-        self.sub = rospy.Subscriber(self.args.topic, getattr(i, type[1][:-1]), callback=self.callback)
+        self.sub = rospy.Subscriber(self.args.topic, getattr(i, type[1][:-1]),
+                                    callback=self.callback)
         print "Subscribed to {}".format(self.args.topic)
         self.data = []
 
@@ -29,7 +31,9 @@ class Histogram():
         self.data.append(eval('msg.' + self.args.attribute))
 
     def plot(self):
-        n, bins, patches = plt.hist(self.data, 'auto', normed=self.args.normed, facecolor=self.args.color, alpha=self.args.alpha)
+        n, bins, patches = plt.hist(self.data, 'auto', normed=self.args.normed,
+                                    facecolor=self.args.color,
+                                    alpha=self.args.alpha)
 
         if self.args.normed:
             plt.ylabel('Probability')
@@ -51,7 +55,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('topic', help="Topic to plot data from")
     parser.add_argument('attribute', help="Attribute of the message to plot")
-    parser.add_argument('--normed', action='store_true', default=False, 
+    parser.add_argument('--normed', action='store_true', default=False,
                         help="Normalize the data in the Histogram")
     parser.add_argument('--color', default='blue',
                         help="Choose the color of the bars in the plot")

--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -26,12 +26,12 @@ class Histogram():
 
     def callback(self, msg):
         print "Got Message"
-        self.data.append(eval('msg.' + args.attribute))
+        self.data.append(eval('msg.' + self.args.attribute))
 
     def plot(self):
-        n, bins, patches = plt.hist(self.data, 50, normed=args.normed, facecolor=args.color, alpha=args.alpha)
+        n, bins, patches = plt.hist(self.data, 'auto', normed=self.args.normed, facecolor=self.args.color, alpha=self.args.alpha)
 
-        if args.normed:
+        if self.args.normed:
             plt.ylabel('Probability')
         else:
             plt.ylabel('Number')


### PR DESCRIPTION
#43 is started with this PR. The script will use auto binning to determine the number of bins to generate for the plot. numpy version must be >=1.11.0 for the auto binning to work.

Example usage:
`python histogram.py /depth depth`
The ordering for the arguments is topic then what value from the message to use for the histogram.