### PR TITLE
Updated control.launch to use cobalt.yaml

### DIFF
--- a/launch/cameras.launch
+++ b/launch/cameras.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
 
     <arg name="left_serial" default="14406637"/>

--- a/launch/control.launch
+++ b/launch/control.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 
 <launch>
-	<node pkg="robosub" type="control" name="control" required="false"/>
-    <rosparam command="load" file="$(find robosub)/param/thruster.yaml" />
-    <rosparam command="load" file="$(find robosub)/param/control.yaml" />
+    <arg name="sub_name" default="cobalt"/>
+
+    <rosparam command="load" file="$(find robosub)/param/$(arg sub_name).yaml"/>
+    <node pkg="robosub" type="control" name="control" required="false"/>
 </launch>

--- a/launch/core.launch
+++ b/launch/core.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
 <!--This launchfile should contain important nodes that we should always have
 running, such as the UPS power monitor. This launchfile will be run as a system

--- a/launch/joystick.launch
+++ b/launch/joystick.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
     <node name="joystick_control" pkg="robosub" type="joystick_control" />
     <node name="joystick_driver" pkg="robosub" type="joystick_driver" />

--- a/launch/movement.launch
+++ b/launch/movement.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
     <include file="$(find robosub)/launch/include/movement_$(env ROBOSUB_NAME).xml" />
     <rosparam command="load" file="$(find robosub)/param/$(env ROBOSUB_NAME).yaml" />

--- a/launch/sim.launch
+++ b/launch/sim.launch
@@ -1,5 +1,0 @@
-<?xml version="1.0"?>
-<launch>
-	<node pkg="robosub" type="unity_bridge.py" name="unity_bridge" required="true"/>
-	<node pkg="robosub" type="image_publisher" name="image_publisher" required="true"/>
-</launch>


### PR DESCRIPTION
The control launch file now uses the cobalt parameter file or any other sub param file given that the argument `sub_name` is set correctly (defaults to "cobalt"). Also removed sim.launch as it references the old simulator. This fixes #121.