### PR TITLE
Multiple Histograms on one plot

### DIFF
--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -10,33 +10,55 @@ class Histogram():
     def __init__(self, arguments):
         self.args = arguments
 
-        # Get the class type of the requested topic, blocking until it exists
-        t_type = rostopic.get_topic_class(self.args.topic, blocking=True)
+        self.data = {}
 
-        # Subscribe to the topic
-        self.sub = rospy.Subscriber(self.args.topic, t_type[0],
-                                    callback=self.callback)
+        self.labels = []
 
-        rospy.loginfo("Subscribed to {}".format(self.args.topic))
-        self.data = []
+        for i in range(0,len(self.args.topics)):
+
+            # Get the class type of the requested topic, blocking until it exists
+            t_type = rostopic.get_topic_class(self.args.topics[i], blocking=True)
+
+            # Subscribe to the topic
+            self.sub = rospy.Subscriber(self.args.topics[i], t_type[0],
+                                        callback=self.callback, callback_args=self.args.topics[i])
+
+            rospy.loginfo("Subscribed to {}".format(self.args.topics[i]))
+
+            self.data[self.args.topics[i]] = {}
+
+            self.data[self.args.topics[i]]['data'] = []
+            self.data[self.args.topics[i]]['attr'] = self.args.attributes[i]
+
+            self.labels.append(self.args.topics[i] + '/' + self.args.attributes[i])
 
         plt.ion()
         plt.show()
 
-    def callback(self, msg):
-        rospy.logdebug("Got {} Message".format(self.args.topic))
-        self.data.append(eval('msg.' + self.args.attribute))
+    def callback(self, msg, topic):
+        rospy.logdebug("Got {} Message".format(topic))
+        self.data[topic]['data'].append(eval('msg.' + self.data[topic]['attr']))
 
     def plot(self):
         rospy.logdebug("Plotting Update")
+        plt_data = []
+        for value in self.data.values():
+            plt_data.append(value['data'])
+
+        plt_data = np.array(plt_data).T
+
         try:
-            n, bins, patches = plt.hist(self.data, int(self.args.bins),
-                                        normed=1, facecolor=self.args.color,
-                                        alpha=self.args.alpha)
+            n, bins, patches = plt.hist(plt_data, int(self.args.bins),
+                                        color=['blue', 'red'], histtype='bar',
+                                        normed=1,
+                                        alpha=self.args.alpha,
+                                        label=self.labels)
         except ValueError:
-            n, bins, patches = plt.hist(self.data, self.args.bins, normed=1,
-                                        facecolor=self.args.color,
-                                        alpha=self.args.alpha)
+            n, bins, patches = plt.hist(plt_data, self.args.bins, normed=1,
+                                        color=['blue', 'red'], histtype='bar',
+                                        alpha=self.args.alpha,
+                                        label=self.labels
+                                        )
 
         if self.args.normed:
             plt.ylabel('Probability')
@@ -44,7 +66,9 @@ class Histogram():
             plt.ylabel('Number')
 
         plt.xlabel('Value')
-        plt.title('Histogram of {}'.format(args.topic))
+        plt.title('Histogram')
+
+        plt.legend()
 
         plt.pause(0.05)
         plt.gca().clear()
@@ -63,8 +87,8 @@ if __name__ == "__main__":
     rospy.init_node("Histogram", anonymous=True)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('topic', help="Topic to plot data from")
-    parser.add_argument('attribute', help="Attribute of the message to plot")
+    parser.add_argument('--topics', nargs='+', help="Topic to plot data from")
+    parser.add_argument('--attributes', nargs='+', help="Attribute of the message to plot")
     parser.add_argument('--normed', action='store_true', default=False,
                         help="Normalize the data in the Histogram")
     parser.add_argument('--color', default='blue',

--- a/scripts/histogram.py
+++ b/scripts/histogram.py
@@ -14,48 +14,63 @@ class Histogram():
 
         self.labels = []
 
-        for i in range(0,len(self.args.topics)):
+        for i in range(0, len(self.args.topics)):
 
-            # Get the class type of the requested topic, blocking until it exists
-            t_type = rostopic.get_topic_class(self.args.topics[i], blocking=True)
+            # Get the class type of the requested topic, block until it exists
+            t_type = rostopic.get_topic_class(self.args.topics[i],
+                                              blocking=True)
 
-            # Subscribe to the topic
-            self.sub = rospy.Subscriber(self.args.topics[i], t_type[0],
-                                        callback=self.callback, callback_args=self.args.topics[i])
+            if self.args.topics[i] not in self.data:
+                # Subscribe to the topic
+                self.sub = rospy.Subscriber(self.args.topics[i], t_type[0],
+                                            callback=self.callback,
+                                            callback_args=self.args.topics[i])
 
-            rospy.loginfo("Subscribed to {}".format(self.args.topics[i]))
+                rospy.loginfo("Subscribed to {}".format(self.args.topics[i]))
 
-            self.data[self.args.topics[i]] = {}
+                self.data[self.args.topics[i]] = {}
 
-            self.data[self.args.topics[i]]['data'] = []
-            self.data[self.args.topics[i]]['attr'] = self.args.attributes[i]
+                self.data[self.args.topics[i]]['data'] = [[]]
+                self.data[self.args.topics[i]]['attr'] = []
+                self.data[self.args.topics[i]]['attr'].append(
+                        self.args.attributes[i])
 
-            self.labels.append(self.args.topics[i] + '/' + self.args.attributes[i])
+            else:
+                self.data[self.args.topics[i]]['data'].append([])
+                self.data[self.args.topics[i]]['attr'].append(
+                        self.args.attributes[i])
+
+            self.labels.append(self.args.topics[i] + '/' +
+                               self.args.attributes[i])
 
         plt.ion()
         plt.show()
 
     def callback(self, msg, topic):
         rospy.logdebug("Got {} Message".format(topic))
-        self.data[topic]['data'].append(eval('msg.' + self.data[topic]['attr']))
+        for i in range(0, len(self.data[topic]['attr'])):
+            self.data[topic]['data'][i].append(eval('msg.' +
+                                                    self.data[topic]['attr'][i])
+                                               )
 
     def plot(self):
         rospy.logdebug("Plotting Update")
         plt_data = []
         for value in self.data.values():
-            plt_data.append(value['data'])
+            for i in range(0, len(value['data'])):
+                plt_data.append(value['data'][i])
 
         plt_data = np.array(plt_data).T
+        print plt_data
 
         try:
             n, bins, patches = plt.hist(plt_data, int(self.args.bins),
-                                        color=['blue', 'red'], histtype='bar',
-                                        normed=1,
+                                        histtype='bar', normed=self.args.normed,
                                         alpha=self.args.alpha,
                                         label=self.labels)
         except ValueError:
-            n, bins, patches = plt.hist(plt_data, self.args.bins, normed=1,
-                                        color=['blue', 'red'], histtype='bar',
+            n, bins, patches = plt.hist(plt_data, self.args.bins,
+                                        normed=self.args.normed, histtype='bar',
                                         alpha=self.args.alpha,
                                         label=self.labels
                                         )
@@ -88,11 +103,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--topics', nargs='+', help="Topic to plot data from")
-    parser.add_argument('--attributes', nargs='+', help="Attribute of the message to plot")
+    parser.add_argument('--attributes', nargs='+',
+                        help="Attribute of the message to plot")
     parser.add_argument('--normed', action='store_true', default=False,
                         help="Normalize the data in the Histogram")
-    parser.add_argument('--color', default='blue',
-                        help="Choose the color of the bars in the plot")
     parser.add_argument('--alpha', type=float, default=0.75,
                         help="Alpha of the color to use")
     parser.add_argument('--bins', default='auto',


### PR DESCRIPTION
The plotter can now plot multiple histograms at the same time. This comes at the cost of a longer command. Auto-binning will currently not work with more than one histogram (Will work on in the future), for now just specify a reasonable number of bins (10 is usually good).

Usage
`./histogram.py --topics /depth /position /position --attributes depth x y --bins 10`