### PR TITLE
Added in correct names for default serial ports

### DIFF
--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -1,6 +1,6 @@
 ports:
-    thruster: "/"
-    sensor: "/dev/ttyUSB0"
+    thruster: "/dev/maestro_control"
+    sensor: "/dev/bno055"
 thrusters:
     -   name: "dive_front_left"
         channel: 8


### PR DESCRIPTION
I created udev rules for the bno055 and put them in the rules folder to name the device bno055. Note that in the future, we will need to update this rule when using multiple interface converters. We will need to program the EEPROM to give each device a unique serial number so that the rule does not conflict with other devices, but for now this should be fine since there's only one. (The EEPROM configuration tool is windows :( )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/155)
<!-- Reviewable:end -->
