### PR TITLE
Modifies MaestroDriver to map input normalized force commands to output PWM signals

### DIFF
--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -2,99 +2,91 @@ ports:
     thruster: "/dev/maestro_control"
     sensor: "/dev/bno055"
 thrusters:
-    -   name: "dive_front_left"
-        channel: 8
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 0.0
-            z: -1.0
-        position:
-            x: 0.235
-            y: 0.23
-            z: -0.1
-    -   name: "dive_front_right"
-        channel: 7
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 0.0
-            z: -1.0
-        position:
-            x: 0.235
-            y: -0.23
-            z: -0.1
-    -   name: "dive_back_left"
-        channel: 4
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 0.0
-            z: -1.0
-        position:
-            x: -0.235
-            y: 0.23
-            z: -0.1
-    -   name: "dive_back_right"
-        channel: 6
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 0.0
-            z: -1.0
-        position:
-            x: -0.235
-            y: -0.23
-            z: -0.1
-    -   name: "strafe_front"
-        channel: 9
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 1.0
-            z: 0.0
-        position:
-            x: 0.46
-            y: 0.0
-            z: -0.01
-    -   name: "strafe_back"
-        channel: 0
-        max_speed: 0.6
-        orientation:
-            x: 0.0
-            y: 1.0
-            z: 0.0
-        position:
-            x: -0.46
-            y: 0.0
-            z: -0.01
-    -   name: "forward_left"
-        channel: 10
-        max_speed: 0.6
-        orientation:
-            x: -1.0
-            y: 0.0
-            z: 0.0
-        position:
-            x: 0.0
-            y: 0.2075
-            z: -0.01
-    -   name: "forward_right"
-        channel: 1
-        max_speed: 0.6
-        orientation:
-            x: -1.0
-            y: 0.0
-            z: 0.0
-        position:
-            x: 0.0
-            y: -0.2075
-            z: -0.01
+    max_thrust: 24
+    mapping:
+        -   name: "dive_front_left"
+            channel: 8
+            orientation:
+                x: 0.0
+                y: 0.0
+                z: -1.0
+            position:
+                x: 0.235
+                y: 0.23
+                z: -0.1
+        -   name: "dive_front_right"
+            channel: 7
+            orientation:
+                x: 0.0
+                y: 0.0
+                z: -1.0
+            position:
+                x: 0.235
+                y: -0.23
+                z: -0.1
+        -   name: "dive_back_left"
+            channel: 4
+            orientation:
+                x: 0.0
+                y: 0.0
+                z: -1.0
+            position:
+                x: -0.235
+                y: 0.23
+                z: -0.1
+        -   name: "dive_back_right"
+            channel: 6
+            orientation:
+                x: 0.0
+                y: 0.0
+                z: -1.0
+            position:
+                x: -0.235
+                y: -0.23
+                z: -0.1
+        -   name: "strafe_front"
+            channel: 9
+            orientation:
+                x: 0.0
+                y: 1.0
+                z: 0.0
+            position:
+                x: 0.46
+                y: 0.0
+                z: -0.01
+        -   name: "strafe_back"
+            channel: 0
+            orientation:
+                x: 0.0
+                y: 1.0
+                z: 0.0
+            position:
+                x: -0.46
+                y: 0.0
+                z: -0.01
+        -   name: "forward_left"
+            channel: 10
+            orientation:
+                x: -1.0
+                y: 0.0
+                z: 0.0
+            position:
+                x: 0.0
+                y: 0.2075
+                z: -0.01
+        -   name: "forward_right"
+            channel: 1
+            orientation:
+                x: -1.0
+                y: 0.0
+                z: 0.0
+            position:
+                x: 0.0
+                y: -0.2075
+                z: -0.01
 control:
     rate: 10
     mass: 27.0
-    back_thrust_ratio: 0.8
-    max_thrust: 50.0
     inertia:
         psi: 1.0
         phi: 1.0

--- a/src/movement/CMakeLists.txt
+++ b/src/movement/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 #thruster nodes
-add_ros_node(thruster_maestro thruster_maestro.cpp maestro_thruster_controller.cpp)
+add_ros_node(thruster_maestro thruster_maestro.cpp MaestroThrusterDriver.cpp)
 target_link_libraries(thruster_maestro serial)
 
 add_ros_node(thruster_sabertooth thruster_sabertooth.cpp)

--- a/src/movement/CMakeLists.txt
+++ b/src/movement/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 #thruster nodes
-add_ros_node(thruster_maestro thruster_maestro.cpp MaestroThrusterDriver.cpp)
+add_ros_node(thruster_maestro thruster_maestro.cpp maestro_thruster_driver.cpp)
 target_link_libraries(thruster_maestro serial)
 
 add_ros_node(thruster_sabertooth thruster_sabertooth.cpp)

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -7,12 +7,7 @@ namespace rs
      * Constructor.
      */
     MaestroThrusterDriver::MaestroThrusterDriver() :
-        _is_initialized(false),
-        _port(nullptr),
-        _max_speed(),
-        _post_reset_delay_ms(185),
-        _next_reset(),
-        _max_thrust_kgf(0)
+        _is_initialized(false)
     {
     }
 
@@ -57,7 +52,7 @@ namespace rs
             ROS_ERROR("Failed to load maximum thruster force.");
             return -1;
         }
-        if (ros::param::getCached("control/back_thrust_ratio",
+        if (ros::param::get("control/back_thrust_ratio",
                     back_thrust_ratio) == false)
         {
             ROS_ERROR("Failed to load the back thrust ratio.");
@@ -263,7 +258,7 @@ namespace rs
           * to 1100 for negative and up to 1900 for positive
           * signals.
           */
-         int signal = 0;
+         uint16_t signal = 0;
          const double force_kgf = normalized_force * _max_thrust_kgf;
 
          if (force_kgf > 0)

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -267,7 +267,7 @@ namespace rs
             force_kgf = 0;
          }
 
-         ROS_INFO_STREAM("Force (KgF): " << force_kgf);
+         ROS_DEBUG_STREAM("Force (KgF): " << force_kgf);
 
          if (force_kgf > 0)
          {

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -1,4 +1,4 @@
-#include "MaestroThrusterDriver"
+#include "MaestroThrusterDriver.h"
 #include <map>
 
 namespace rs
@@ -11,7 +11,7 @@ namespace rs
         _port(nullptr),
         _max_speed(),
         _post_reset_delay_ms(185),
-        _next_reset(),
+        _next_reset()
     {
     }
 
@@ -93,7 +93,7 @@ namespace rs
             return -1;
         }
 
-        const uint8_t detect_byte = 0xAA;
+        uint8_t detect_byte = 0xAA;
         if (port->Write(&detect_byte, 1) != 1)
         {
             ROS_ERROR("Serial port failed to write baud-detection bit.");
@@ -156,7 +156,7 @@ namespace rs
              * the zero pulse, which will cause it to malfunction
              */
             ros::Duration(
-                    static_cast<double>(_post_reset_delay_ms/1000).sleep();
+                    static_cast<double>(_post_reset_delay_ms/1000)).sleep();
         }
 
         /*

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -31,7 +31,6 @@ namespace rs
      *        thrusters. This port may be changed during runtime.
      */
     int MaestroThrusterDriver::init(
-                            std::map<uint8_t, double> max_speed,
                             Serial *port,
                             const double post_reset_delay_ms)
     {
@@ -45,27 +44,18 @@ namespace rs
          * ratio from the settings.
          */
         double max_thrust_newtons = 0;
-        double back_thrust_ratio = 0;
-        if (ros::param::get("control/max_thrust", max_thrust_newtons) ==
+        if (ros::param::get("thrusters/max_thrust", max_thrust_newtons) ==
                 false)
         {
             ROS_ERROR("Failed to load maximum thruster force.");
             return -1;
         }
-        if (ros::param::get("control/back_thrust_ratio",
-                    back_thrust_ratio) == false)
-        {
-            ROS_ERROR("Failed to load the back thrust ratio.");
-            return -1;
-        }
 
         /*
-         * Convert the maximum thrust available in any given
-         * direction to be the back thrust ratio multiplied by the
-         * maximum thrust converted to KgF. The scaling factor
-         * for converting newtons to KgF is 0.101972.
+         * The scaling factor for converting newtons to KgF is
+         * 0.101972. Convert the Newtonian thrust into KgF.
          */
-        _max_thrust_kgf = max_thrust_newtons * 0.101972 * back_thrust_ratio;
+        _max_thrust_kgf = max_thrust_newtons * 0.101972;
         ROS_INFO_STREAM("Maximum thrust in KgF: " << _max_thrust_kgf);
 
         /*
@@ -76,17 +66,6 @@ namespace rs
         for(uint8_t i = 0; i < max_thrusters; ++i)
         {
             _next_reset[i] = now;
-            _max_speed[i] = 0.0;
-        }
-
-        /*
-         * Properly overwrite the max speed of zero with provided max speed
-         * values.
-         */
-        for (auto iter = max_speed.begin(); iter != max_speed.end(); iter++)
-        {
-            const uint8_t thruster_key = iter->first;
-            _max_speed[thruster_key] = max_speed[thruster_key];
         }
 
         _post_reset_delay_ms = post_reset_delay_ms;
@@ -192,12 +171,6 @@ namespace rs
             return -1;
         }
 
-        if(fabs(speed) > _max_speed[channel])
-        {
-            ROS_DEBUG_THROTTLE(1, "Software-limiting thruster speed.");
-            speed = _max_speed[channel] * ((speed < 0)? -1 : 1);
-        }
-
         const int signal = parseNormalized(speed, command[3], command[2]);
 
         if (signal < 0)
@@ -239,61 +212,76 @@ namespace rs
      * @return The thruster command signal on success and -1 on
      *         failure.
      */
-     int MaestroThrusterDriver::parseNormalized(const double normalized_force,
-                                                    uint8_t &msb, uint8_t &lsb)
-     {
-         if (normalized_force < -1 || normalized_force > 1)
-         {
-             return -1;
-         }
+    int MaestroThrusterDriver::parseNormalized(const double normalized_force,
+                                                   uint8_t &msb, uint8_t &lsb)
+    {
+        if (normalized_force < -1 || normalized_force > 1)
+        {
+            return -1;
+        }
 
-         /*
-          * To convert the normalized speed into a thruster
-          * command, the two characteristic equations found for
-          * either positive or negative force need to be applied
-          * to the desired thrust output. The characteristic
-          * equations take in the thrust as KgF, so convert the
-          * normalized thrust value to KgF. The result of this polynomial will
-          * be the signal to send to the thruster. Note that
-          * thruster signals are centered around 1500, going down
-          * to 1100 for negative and up to 1900 for positive
-          * signals.
-          */
-         uint16_t signal = 0;
-         double force_kgf = normalized_force * _max_thrust_kgf;
+        /*
+         * To convert the normalized speed into a thruster
+         * command, the two characteristic equations found for
+         * either positive or negative force need to be applied
+         * to the desired thrust output. The characteristic
+         * equations take in the thrust as KgF, so convert the
+         * normalized thrust value to KgF. The result of this polynomial will
+         * be the signal to send to the thruster. Note that
+         * thruster signals are centered around 1500, going down
+         * to 1100 for negative and up to 1900 for positive
+         * signals.
+         */
+        uint16_t signal = 0;
+        double force_kgf = normalized_force * _max_thrust_kgf;
 
-         if (std::fabs(force_kgf) < _minimum_thrust_kgf)
-         {
+        if (std::fabs(force_kgf) < _minimum_thrust_kgf)
+        {
             force_kgf = 0;
-         }
+        }
 
-         ROS_DEBUG_STREAM("Force (KgF): " << force_kgf);
+        ROS_DEBUG_STREAM("Force (KgF): " << force_kgf);
 
-         if (force_kgf > 0)
-         {
+        if (force_kgf > 0)
+        {
             signal = a_positive * pow(force_kgf, 3) +
                      b_positive * pow(force_kgf, 2) +
                      c_positive * force_kgf +
                      d_positive;
-         }
-         else if (force_kgf < 0)
-         {
+        }
+        else if (force_kgf < 0)
+        {
             signal = a_negative * pow(force_kgf, 3) +
                      b_negative * pow(force_kgf, 2) +
                      c_negative * force_kgf +
                      d_negative;
-         }
-         else
-         {
+        }
+        else
+        {
             signal = 1500;
-         }
+        }
 
-         /*
-          * Store results into supplied locations.
-          */
-         msb = signal >> 7;
-         lsb = signal & 0x7F;
+        /*
+         * Implement a software hard limit on the signals being sent to the
+         * thrusters to ensure that they do not draw over 10 Amps of current.
+         */
+        if (signal > 1780)
+        {
+            signal = 1780;
+            ROS_WARN("Software hard-limitting thrusters forward.");
+        }
+        else if (signal < 1230)
+        {
+            signal = 1230;
+            ROS_WARN("Software hard-limitting thrusters in reverse.");
+        }
 
-         return signal;
-     }
+        /*
+         * Store results into supplied locations.
+         */
+        msb = signal >> 7;
+        lsb = signal & 0x7F;
+
+        return signal;
+    }
 }

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -194,7 +194,7 @@ namespace rs
 
         if(fabs(speed) > _max_speed[channel])
         {
-            ROS_INFO("Software-limiting thruster speed.");
+            ROS_DEBUG_THROTTLE(1, "Software-limiting thruster speed.");
             speed = _max_speed[channel] * ((speed < 0)? -1 : 1);
         }
 
@@ -214,7 +214,7 @@ namespace rs
          */
         if (signal != 1500 && abs(signal - 1500) < 25)
         {
-            ROS_INFO("Parsed signal is in thruster dead-band.");
+            ROS_WARN("Parsed signal is in thruster dead-band.");
         }
 
         /*

--- a/src/movement/MaestroThrusterDriver.cpp
+++ b/src/movement/MaestroThrusterDriver.cpp
@@ -46,7 +46,7 @@ namespace rs
          */
         double max_thrust_newtons = 0;
         double back_thrust_ratio = 0;
-        if (ros::param::getCached("control/max_thrust", max_thrust_newtons) ==
+        if (ros::param::get("control/max_thrust", max_thrust_newtons) ==
                 false)
         {
             ROS_ERROR("Failed to load maximum thruster force.");

--- a/src/movement/MaestroThrusterDriver.h
+++ b/src/movement/MaestroThrusterDriver.h
@@ -61,8 +61,8 @@ public:
 
     ~MaestroThrusterDriver();
 
-    int init(std::map<uint8_t, double> max_speed, Serial *port,
-        const double post_reset_delay_ms = min_post_reset_delay_ms );
+    int init(Serial *port,
+            const double post_reset_delay_ms = min_post_reset_delay_ms);
 
     int set(double speed, const uint8_t &channel);
 
@@ -77,11 +77,6 @@ private:
      * Maestro.
      */
     Serial *_port;
-
-    /*
-     * The maximum speed setting that a thruster may be set to.
-     */
-    std::map<uint8_t, double> _max_speed;
 
     /*
      * The delay (in milliseconds) to sleep after every reset cycle.  This

--- a/src/movement/MaestroThrusterDriver.h
+++ b/src/movement/MaestroThrusterDriver.h
@@ -60,7 +60,7 @@ public:
     ~MaestroThrusterDriver();
 
     int init(std::map<uint8_t, double> max_speed, Serial *port,
-        const int post_reset_delay_ms = min_post_reset_delay_ms );
+        const double post_reset_delay_ms = min_post_reset_delay_ms );
 
     int set(double speed, const uint8_t &channel);
 

--- a/src/movement/MaestroThrusterDriver.h
+++ b/src/movement/MaestroThrusterDriver.h
@@ -10,8 +10,8 @@
  *       subsection 5.
  */
 
-#ifndef MAESTRO_THRUSTER_DRIVER_H
-#define MAESTRO_THRUSTER_DRIVER_H
+#ifndef MAESTROTHRUSTERDRIVER_H
+#define MAESTROTHRUSTERDRIVER_H
 
 #include <map>
 #include <ros/ros.h>
@@ -98,6 +98,12 @@ private:
     std::map<uint8_t, ros::Time> _next_reset;
 
     /*
+     * Specifies the maximum thrust that may be applied in either
+     * direction in units of kgf.
+     */
+    double _max_thrust_kgf;
+
+    /*
      * These values describe the characteristic polynomials fit
      * to the BlueRobotics T200 thruster data for both positive
      * thrust and negative thrust respectively. The equation
@@ -109,15 +115,15 @@ private:
      * negative data from BlueRobotics separately with a cubic
      * polynomial fit.
      */
-    const double a_negative = 0.344109681;
-    const double b_negative = 5.60788321;
-    const double c_negative = 62.9115428;
-    const double d_negative = 1466.87528;
+    const double a_negative = 3.13223349;
+    const double b_negative = 24.45656912;
+    const double c_negative = 135.16956211;
+    const double d_negative = 1466.0982307;
 
-    const double a_positive = 0.246947716;
-    const double b_positive = -5.22636229;
-    const double c_positive = 62.7351509;
-    const double d_positive = 1513.80845;
+    const double a_positive = 2.64609994;
+    const double b_positive = -25.40194653;
+    const double c_positive = 138.30716827;
+    const double d_positive = 1513.80844695;
 
     /**
      * Maestro-defined serial bytes that have special meaning to the
@@ -211,4 +217,4 @@ private:
 };
 }
 
-#endif // MAESTRO_THRUSTER_DRIVER_H
+#endif // MAESTROTHRUSTERDRIVER_H

--- a/src/movement/MaestroThrusterDriver.h
+++ b/src/movement/MaestroThrusterDriver.h
@@ -43,6 +43,8 @@ class MaestroThrusterDriver
      */
     static constexpr double reset_timeout = 120.0;
 
+    static constexpr double _minimum_thrust_kgf = 0.01;
+
     /*
      * The number of thrusters to be controlled by the Maestro.
      */
@@ -120,10 +122,10 @@ private:
     const double c_negative = 135.16956211;
     const double d_negative = 1466.0982307;
 
-    const double a_positive = 2.64609994;
-    const double b_positive = -25.40194653;
-    const double c_positive = 138.30716827;
-    const double d_positive = 1513.80844695;
+    const double a_positive = 1.23903743;
+    const double b_positive = -13.2491571;
+    const double c_positive = 108.242813;
+    const double d_positive = 1532.70802;
 
     /**
      * Maestro-defined serial bytes that have special meaning to the

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -123,13 +123,6 @@ private:
     double max_thrust;
 
     /*
-     * Defines the maximum ratio of thruster when a thruster is operating in
-     * reverse direction. For example, the back thrust ratio could be 80% of
-     * nominal.
-     */
-    double back_thrust_ratio;
-
-    /*
      * Defines the current state of the submarine. This vector stores elements
      * in the following order:
      *      X, Y, Z, Psi (roll), Phi (pitch), Theta (yaw)

--- a/src/movement/maestro_thruster_driver.cpp
+++ b/src/movement/maestro_thruster_driver.cpp
@@ -1,5 +1,4 @@
-#include "MaestroThrusterDriver.h"
-#include <map>
+#include "movement/maestro_thruster_driver.h"
 
 namespace rs
 {

--- a/src/movement/maestro_thruster_driver.h
+++ b/src/movement/maestro_thruster_driver.h
@@ -10,8 +10,8 @@
  *       subsection 5.
  */
 
-#ifndef MAESTROTHRUSTERDRIVER_H
-#define MAESTROTHRUSTERDRIVER_H
+#ifndef MAESTRO_THRUSTER_DRIVER_H
+#define MAESTRO_THRUSTER_DRIVER_H
 
 #include <map>
 #include <ros/ros.h>
@@ -214,4 +214,4 @@ private:
 };
 }
 
-#endif // MAESTROTHRUSTERDRIVER_H
+#endif // MAESTRO_THRUSTER_DRIVER_H

--- a/src/movement/test/control_system.test
+++ b/src/movement/test/control_system.test
@@ -2,6 +2,7 @@
     <test test-name="test_control_system" pkg="robosub" type="test_control_system" />
 
     <node name="control" pkg="robosub" type="control"/>
+    <node name="thruster_maestro" pkg="robosub" type="thruster_maestro"/>
 
     <rosparam command="load" file="$(find robosub)/param/cobalt.yaml" />
 

--- a/src/movement/test/test_thruster_maestro.cpp
+++ b/src/movement/test/test_thruster_maestro.cpp
@@ -14,7 +14,7 @@
 
 rs::Serial mSerial;
 ros::Publisher pub;
-double byte_check(uint8_t byte2, uint8_t byte3);
+double byte_to_force_ratio(uint8_t byte2, uint8_t byte3);
 std::vector<uint8_t> channels;
 double max_thrust;
 

--- a/src/movement/test/test_thruster_maestro.cpp
+++ b/src/movement/test/test_thruster_maestro.cpp
@@ -104,21 +104,21 @@ double byte_to_force_ratio(uint8_t byte2, uint8_t byte3)
   {
       force_kgf = pow(pulse_width, 3) * -4.85606515e-8 +
                   pow(pulse_width, 2) * 1.78638023e-4 +
-                  pow(pulse_width, 2) * -0.20563003 +
+                  pow(pulse_width, 1) * -0.20563003 +
                   70.4911410;
   }
   else if (pulse_width > 1525)
   {
       force_kgf = pow(pulse_width, 3) * -5.21026922e-8 +
                   pow(pulse_width, 2) * 2.80234148e-4 +
-                  pow(pulse_width, 2) * -0.486381952 +
+                  pow(pulse_width, 1) * -0.486381952 +
                   274.867233;
   }
 
   /*
    * Convert KgF to N and then divide by the maximum force.
    */
-  return force_kgf * 9.80665 / max_thrust;
+  return force_kgf * 9.80665;
 }
 
 int main(int argc, char *argv[])

--- a/src/movement/test/test_thruster_maestro.cpp
+++ b/src/movement/test/test_thruster_maestro.cpp
@@ -64,7 +64,8 @@ TEST(Maestro, basicTest)
         mSerial.Read(maestro_data, 4);
 
         //calculate the thruster speed value of the packet
-        double actual_force = byte_to_force_ratio(maestro_data[2], maestro_data[3]);
+        double actual_force = byte_to_force_ratio(maestro_data[2],
+                maestro_data[3]);
 
         //check to make sure the command and channel bytes are correct.
         EXPECT_EQ(maestro_data[0], 0x84);

--- a/src/movement/thruster_maestro.cpp
+++ b/src/movement/thruster_maestro.cpp
@@ -5,7 +5,7 @@
 #include "ros/ros.h"
 #include "utility/serial.hpp"
 #include "robosub/thruster.h"
-#include "maestro_thruster_controller.hpp"
+#include "MaestroThrusterDriver.h"
 #include <string>
 #include <map>
 #include <vector>
@@ -18,7 +18,7 @@ typedef struct thruster_info
 
 using namespace rs;
 Serial serial;
-MaestroThrusterController thrusterController;
+MaestroThrusterDriver thrusterController;
 std::vector<Thruster_info> mThruster_info;
 
 void Callback (const robosub::thruster::ConstPtr& msg)

--- a/src/movement/thruster_maestro.cpp
+++ b/src/movement/thruster_maestro.cpp
@@ -1,11 +1,7 @@
-/*
- * Michelle Farr - 10/25/2016
- * I am working on this... Haven't tested it at all
- */
-#include "ros/ros.h"
+#include <ros/ros.h>
 #include "utility/serial.hpp"
 #include "robosub/thruster.h"
-#include "MaestroThrusterDriver.h"
+#include "movement/maestro_thruster_driver.h"
 #include <string>
 #include <map>
 #include <vector>

--- a/src/movement/thruster_maestro.cpp
+++ b/src/movement/thruster_maestro.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 
     //Get the ports and names of the maestro thrusters (from coblat.yaml)
     XmlRpc::XmlRpcValue thruster_settings;
-    ros::param::get("thrusters", thruster_settings);
+    ros::param::get("thrusters/mapping", thruster_settings);
 
     for(int i = 0; i < thruster_settings.size(); ++i)
     {
@@ -74,19 +74,15 @@ int main(int argc, char **argv)
                          thruster_settings[i]["name"]);
         ROS_DEBUG_STREAM("thrusters["<< i << "][channel]: " <<
                          thruster_settings[i]["channel"]);
-        ROS_DEBUG_STREAM("thrusters["<< i << "][max_speed]:   " <<
-                         thruster_settings[i]["max_speed"]);
         Thruster_info one_thruster;
         one_thruster.name =
                         static_cast<std::string>(thruster_settings[i]["name"]);
         one_thruster.channel =
                              static_cast<int>(thruster_settings[i]["channel"]);
-        max_speeds[one_thruster.channel] =
-                        static_cast<double>(thruster_settings[i]["max_speed"]);
         mThruster_info.push_back(one_thruster);
     }
 
-    thrusterController.init(max_speeds, &serial);
+    thrusterController.init(&serial);
 
     ros::spin();
 


### PR DESCRIPTION
Please refer to https://github.com/PalouseRobosub/robosub/issues/163 for information, data, and scripts relating to this pull request.

This fix should not be implemented until https://github.com/PalouseRobosub/robosub_simulator/issues/53 is properly implemented and also utilizes polynomial thrust instead of liner so that the change can be tested in simulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/167)
<!-- Reviewable:end -->
