### PR TITLE
Control System Absolute Position

### DIFF
--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -35,9 +35,12 @@ int main(int argc, char **argv)
     ros::Subscriber orientation_sub = nh.subscribe("orientation", 1,
             &ControlSystem::InputOrientationMessage, control_system);
 
+    ros::Subscriber localization_sub = nh.subscribe("position/real", 1,
+            &ControlSystem::InputLocalizationMessage, control_system);
+
     ros::Subscriber control_sub = nh.subscribe("control", 1,
             &ControlSystem::InputControlMessage, control_system);
-
+    
     ros::Publisher pub = nh.advertise<robosub::thruster>("thruster", 1);
 
     rs::ThrottledPublisher<robosub::control_status>

--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 
     ros::Subscriber control_sub = nh.subscribe("control", 1,
             &ControlSystem::InputControlMessage, control_system);
-    
+
     ros::Publisher pub = nh.advertise<robosub::thruster>("thruster", 1);
 
     rs::ThrottledPublisher<robosub::control_status>

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -328,6 +328,24 @@ namespace robosub
     }
 
     /**
+     * Update the current state of the submarine with a localization message
+     *
+     * @brief Updates the current state vector of the submarine given an
+     *        input localization message
+     *
+     * @param vector_msg The input ROS Vector3 geometry message that defines
+     *        position
+     *
+     * @return None.
+     */
+    void ControlSystem::InputLocalizationMessage(
+            const geometry_msgs::Vector3::ConstPtr &vector_msg)
+    {
+        state_vector[0] = vector_msg->x;
+        state_vector[1] = vector_msg->y;
+    }
+
+    /**
      * Update the depth of the submarine.
      *
      * @brief Updates the current state vector with an updated depth reading.

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -43,6 +43,8 @@ public:
     void InputControlMessage(const robosub::control::ConstPtr& msg);
     void InputOrientationMessage(
             const robosub::QuaternionStampedAccuracy::ConstPtr& quat_msg);
+    void InputLocalizationMessage(
+            const geometry_msgs::Vector3::ConstPtr& vector_msg);
     void InputDepthMessage(const robosub::Float32Stamped::ConstPtr& depth_msg);
     void ReloadPIDParams();
     robosub::thruster CalculateThrusterMessage();


### PR DESCRIPTION
Added in a callback which receives a [geometry_msgs/Vector3](http://docs.ros.org/api/geometry_msgs/html/msg/Vector3.html) from **/position/real** as published by the simulator for absolute forward and strafe goals.

Currently, absolute (0,0) is directly above the pinger and positive x is along the yaw 0 direction.

Closes #150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/169)
<!-- Reviewable:end -->
