### PR TITLE
Control fix which changes x errors to be in the global frame

### DIFF
--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -497,8 +497,16 @@ namespace robosub
         Vector3d current_orientation;
         current_orientation[0] = state_vector[3];
         current_orientation[1] = state_vector[4];
-        current_orientation[2] = state_vector[5];
 
+        if (goal_types[0] == robosub::control::STATE_ABSOLUTE ||
+            goal_types[1] == robosub::control::STATE_ABSOLUTE)
+        {
+            current_orientation[2] = state_vector[5];
+        }
+        else
+        {
+            current_orientation[2] = 0;
+        }
         /*
          * Normalize the translational forces based on the current orientation
          * of the submarine and calculate the translation control for each

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -497,7 +497,7 @@ namespace robosub
         Vector3d current_orientation;
         current_orientation[0] = state_vector[3];
         current_orientation[1] = state_vector[4];
-        current_orientation[2] = 0;
+        current_orientation[2] = state_vector[5];
 
         /*
          * Normalize the translational forces based on the current orientation

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -491,8 +491,10 @@ namespace robosub
         /*
          * Grab the current orientation of the submarine for rotating the
          * current translational goals. The order of this vector is roll,
-         * pitch, and yaw.  Note that by setting the yaw to zero, all control
-         * signals are relative.
+         * pitch, and yaw.
+         * 
+         * Yaw is set to 0 to use the relative reference frame when neither
+         * the forward nor strafe state is absolute.
          */
         Vector3d current_orientation;
         current_orientation[0] = state_vector[3];
@@ -501,10 +503,14 @@ namespace robosub
         if (goal_types[0] == robosub::control::STATE_ABSOLUTE ||
             goal_types[1] == robosub::control::STATE_ABSOLUTE)
         {
+            //Use the global reference frame when either x or y
+            // state is absolute
             current_orientation[2] = state_vector[5];
         }
         else
         {
+            //Use the relative reference frame when neither x nor y
+            // state is absolute.
             current_orientation[2] = 0;
         }
         /*


### PR DESCRIPTION
This uses the global reference frame rather than the sub frame of reference. It would probably be a good idea to still have a control method which runs off of the sub reference frame as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/172)
<!-- Reviewable:end -->
