### PR TITLE
Fixes 90 degree or more control errors for rotation in xy plane.

### DIFF
--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -431,6 +431,7 @@ namespace robosub
          */
         rotation_error(1, 0) *= cos(rotation_error(2, 0) * 3.1415 / 180);
 
+        rotation_error(0, 0) *= cos(rotation_error(2, 0) * 3.1415 / 180);
         /*
          * Update the current error vector with the calculated errors.
          */

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -400,6 +400,38 @@ namespace robosub
                 r3D(rotation_goals));
 
         /*
+         * Have yaw pursue the supplement angle to the goal when yaw and roll
+         * errors are both greater than +/- 90 degrees
+         */
+        if (fabs(rotation_error(2,0)) > 90 && fabs(rotation_error(0,0)) > 90)
+        {
+            if (rotation_error(2,0) > 0)
+            {
+                rotation_error(2,0) -= 180;
+            }
+            else
+            {
+                rotation_error(2,0) += 180;
+            }
+
+            if (rotation_error(0,0) > 0)
+            {
+                rotation_error(0,0) -= 180;
+            }
+            else
+            {
+                rotation_error(0,0) += 180;
+            }
+        }
+
+        /* 
+         * Multiply the pitch error by the cosine (in degrees) of the yaw error
+         * to use positive feedback for pitch to assist yaw when yawing more
+         * than 90 degrees.
+         */
+        rotation_error(1,0) *= cos(rotation_error(2,0) * 3.1415 / 180);
+
+        /*
          * Update the current error vector with the calculated errors.
          */
         current_error = Vector6d::Zero();

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -403,24 +403,24 @@ namespace robosub
          * Have yaw pursue the supplement angle to the goal when yaw and roll
          * errors are both greater than +/- 90 degrees
          */
-        if (fabs(rotation_error(2,0)) > 90 && fabs(rotation_error(0,0)) > 90)
+        if (fabs(rotation_error(2, 0)) > 90 && fabs(rotation_error(0, 0)) > 90)
         {
-            if (rotation_error(2,0) > 0)
+            if (rotation_error(2, 0) > 0)
             {
-                rotation_error(2,0) -= 180;
+                rotation_error(2, 0) -= 180;
             }
             else
             {
-                rotation_error(2,0) += 180;
+                rotation_error(2, 0) += 180;
             }
 
-            if (rotation_error(0,0) > 0)
+            if (rotation_error(0, 0) > 0)
             {
-                rotation_error(0,0) -= 180;
+                rotation_error(0, 0) -= 180;
             }
             else
             {
-                rotation_error(0,0) += 180;
+                rotation_error(0, 0) += 180;
             }
         }
 
@@ -429,7 +429,7 @@ namespace robosub
          * to use positive feedback for pitch to assist yaw when yawing more
          * than 90 degrees.
          */
-        rotation_error(1,0) *= cos(rotation_error(2,0) * 3.1415 / 180);
+        rotation_error(1, 0) *= cos(rotation_error(2, 0) * 3.1415 / 180);
 
         /*
          * Update the current error vector with the calculated errors.


### PR DESCRIPTION
Same as #173 except now the roll positive feedback which seemed to be causing many issues is compensated for in the same way that the pitch feedback is.

Fixes #165. A fix for #166 would probably make things even more stable. @btmoore also suggested modeling the buoyancy and other outside forces as thrusters for further robustness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/176)
<!-- Reviewable:end -->
