### PR TITLE
fixed serial hanging issue

### DIFF
--- a/src/utility/serial.cpp
+++ b/src/utility/serial.cpp
@@ -100,7 +100,7 @@ namespace rs
             return -1;
         }
 
-        while(sent < num)
+        while(sent < num && ros::ok())
         {
             i = ::write(this->m_port_fd, buf, num);
             if (i < 0)
@@ -134,7 +134,7 @@ namespace rs
             return -1;
         }
 
-        while(i < num)
+        while(i < num && ros::ok())
         {
             /*
              * Wait for atleast one byte to be available before reading so that


### PR DESCRIPTION
If the serial port closed when we stil had it open, we would hang on a write
operation. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/181)
<!-- Reviewable:end -->
