### PR TITLE
Updating bounds checks for thruster deadband

### DIFF
--- a/src/movement/maestro_thruster_driver.cpp
+++ b/src/movement/maestro_thruster_driver.cpp
@@ -184,7 +184,7 @@ namespace rs
          * if the signal is in the dead-band to inform the
          * operator that the thruster should not spin.
          */
-        if (signal != 1500 && abs(signal - 1500) < 25)
+        if (signal != 6000 && abs(signal/4 - 1500) < 25)
         {
             ROS_WARN("Parsed signal is in thruster dead-band.");
         }


### PR DESCRIPTION
Bounds checking for deadband warnings was not updated with the update to quarter microsecond timing. This adds that in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/185)
<!-- Reviewable:end -->
