### PR TITLE
updated control test to pass new simulator settings

### DIFF
--- a/src/movement/test/control_system.test
+++ b/src/movement/test/control_system.test
@@ -1,9 +1,6 @@
 <launch>
     <test test-name="test_control_system" pkg="robosub" type="test_control_system" />
 
-    <node name="control" pkg="robosub" type="control"/>
-    <node name="thruster_maestro" pkg="robosub" type="delayed_node.sh" args="1 thruster_maestro"/>
-
     <rosparam command="load" file="$(find robosub)/param/cobalt.yaml" />
 
     <include file="$(find robosub_simulator)/launch/gazebo.launch">


### PR DESCRIPTION
the simulator now launches the control system and thruster nodes by itself, so the tests don't need to do it anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/190)
<!-- Reviewable:end -->
