### PR TITLE
Disable control system on startup 

### DIFF
--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -25,6 +25,7 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "control");
 
+
     ros::NodeHandle nh;
 
     control_system = new ControlSystem();
@@ -53,7 +54,10 @@ int main(int argc, char **argv)
     while(ros::ok())
     {
         control_state_pub.publish(control_system->GetControlStatus());
-        pub.publish(control_system->CalculateThrusterMessage());
+        if(isEnabled())
+        {
+          pub.publish(control_system->CalculateThrusterMessage());
+        }
         ros::spinOnce();
         r.sleep();
     }

--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -25,7 +25,6 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "control");
 
-
     ros::NodeHandle nh;
 
     control_system = new ControlSystem();
@@ -54,9 +53,9 @@ int main(int argc, char **argv)
     while(ros::ok())
     {
         control_state_pub.publish(control_system->GetControlStatus());
-        if(isEnabled())
+        if(control_system->isEnabled())
         {
-          pub.publish(control_system->CalculateThrusterMessage());
+            pub.publish(control_system->CalculateThrusterMessage());
         }
         ros::spinOnce();
         r.sleep();

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -10,6 +10,7 @@ namespace robosub
      */
     ControlSystem::ControlSystem()
     {
+        enabled = false;
         ReloadPIDParams();
 
         /*
@@ -133,6 +134,16 @@ namespace robosub
         ROS_INFO_STREAM("Motor Matrix Inverted:\n" << motors_inverted);
     }
 
+
+    /*
+      getter function that returns variable telling us if we should
+      allow thruster message to publish
+    */
+    bool ControlSystem::isEnabled(void)
+    {
+      return enabled;
+    }
+
     /**
      * Reload PID parameters from the ROS parameter server.
      *
@@ -190,6 +201,7 @@ namespace robosub
     void ControlSystem::InputControlMessage(const
             robosub::control::ConstPtr& msg)
     {
+        enabled = true;
         std::vector<double> control_values(6);
         std::vector<uint8_t> control_states(6);
 

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -141,7 +141,7 @@ namespace robosub
     */
     bool ControlSystem::isEnabled(void)
     {
-      return enabled;
+        return enabled;
     }
 
     /**

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -49,8 +49,10 @@ public:
     void ReloadPIDParams();
     robosub::thruster CalculateThrusterMessage();
     robosub::control_status GetControlStatus();
+    bool isEnabled();
 
 private:
+    bool enabled;
     void calculate_motor_control();
     double wraparound(double x, double min, double max);
     std::string state_to_string(uint8_t state);


### PR DESCRIPTION
the thruster message function was chenged so that the thruster only publishes when we receive a control system message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/220)
<!-- Reviewable:end -->
