### PR TITLE
Rate Namespace Fix

### DIFF
--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -4,7 +4,7 @@ ports:
 rate:
     control: 50
     depth: 10
-    sensor: 20
+    imu: 20
 thrusters:
     max_thrust: 24
     timeout: 2.0

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -290,9 +290,9 @@ int main(int argc, char **argv)
      * Enter the main ROS loop.
      */
     int rate;
-    if (!nh.getParam("rate/sensor", rate))
+    if (!nh.getParam("rate/imu", rate))
     {
-        ROS_WARN("Failed to load sensor node rate. Falling back to 20Hz.");
+        ROS_WARN("Failed to load BNO055 node rate. Falling back to 20Hz.");
         rate = 20;
     }
     ros::Rate r(rate);


### PR DESCRIPTION
The sister PR to PalouseRobosub/robosub_simulator#84. This changes the rate/sensor parameter to be rate/imu to clarify its use.

@ryan-summers, I was looking at the names of some of the other parameters and a similar issue shows up with the serial port parameter `ports/sensor` and the entire sensor namespace which contains the imu parameters. Thoughts? 

Also, are we planning on keeping the [ironman.yaml](https://github.com/PalouseRobosub/robosub/blob/dev/param/ironman.yaml) file up to date? If so, I'll need to update it as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/232)
<!-- Reviewable:end -->
