### PR TITLE
Fix for the installation issue on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ branches:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://mirror.umd.edu/packages.ros.org/ros/ubuntu trusty     main'
+    - sourceline: 'deb http://packages.ros.org/ros/ubuntu trusty main'
       key_url: 'https://raw.githubusercontent.com/ros/rosdistro/master/ros.key '
     - sourceline: 'deb http://robosub.eecs.wsu.edu/repo/ /'
       key_url: 'http://robosub.eecs.wsu.edu/repo/repository_key'


### PR DESCRIPTION
The UMD mirror seems to be having problems, switching to the default packages.ros.org mirror.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/233)
<!-- Reviewable:end -->
