### PR TITLE
Updating sensors to remove QuaternionStampedAccuracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ add_message_files(
   gamepad.msg
   Float32Stamped.msg
   Euler.msg
-  QuaternionStampedAccuracy.msg
   HydrophoneDeltas.msg
   Position.msg
   PositionArrayStamped.msg

--- a/msg/QuaternionStampedAccuracy.msg
+++ b/msg/QuaternionStampedAccuracy.msg
@@ -1,3 +1,0 @@
-std_msgs/Header header
-geometry_msgs/Quaternion quaternion
-float32 accuracy

--- a/src/localization/robosub_sensors.cpp
+++ b/src/localization/robosub_sensors.cpp
@@ -67,7 +67,7 @@ void RobosubSensors::InputHydrophones(const
 }
 
 void RobosubSensors::InputOrientation(const
-        robosub::QuaternionStampedAccuracy::ConstPtr &msg)
+        geometry_msgs::QuaternionStamped::ConstPtr &msg)
 {
     orientation = tf::Quaternion(msg->quaternion.x, msg->quaternion.y,
                                  msg->quaternion.z, msg->quaternion.w);

--- a/src/localization/robosub_sensors.h
+++ b/src/localization/robosub_sensors.h
@@ -5,7 +5,7 @@
 #include "ros/ros.h"
 #include "tf/transform_datatypes.h"
 
-#include "robosub/QuaternionStampedAccuracy.h"
+#include "geometry_msgs/QuaternionStamped.h"
 #include "robosub/Float32Stamped.h"
 #include "robosub/PositionArrayStamped.h"
 #include "geometry_msgs/Vector3Stamped.h"
@@ -32,7 +32,7 @@ public:
     void InputRelLinAcl(const geometry_msgs::Vector3Stamped::ConstPtr &msg);
     void InputDepth(const robosub::Float32Stamped::ConstPtr &msg);
     void InputHydrophones(const robosub::PositionArrayStamped::ConstPtr &msg);
-    void InputOrientation(const robosub::QuaternionStampedAccuracy::ConstPtr
+    void InputOrientation(const geometry_msgs::QuaternionStamped::ConstPtr
                           &msg);
 
     // Inputs for derived data

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -310,7 +310,7 @@ namespace robosub
      * @return None.
      */
     void ControlSystem::InputOrientationMessage(
-            const robosub::QuaternionStampedAccuracy::ConstPtr &quat_msg)
+            const geometry_msgs::QuaternionStamped::ConstPtr &quat_msg)
     {
         /*
          * Convert the Quaternion to roll, pitch, and yaw and store the result

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -8,7 +8,7 @@
 
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Vector3.h"
-#include "robosub/QuaternionStampedAccuracy.h"
+#include "geometry_msgs/QuaternionStamped.h"
 #include "robosub/control.h"
 #include "robosub/control_status.h"
 #include "robosub/Float32Stamped.h"
@@ -42,7 +42,7 @@ public:
     ControlSystem();
     void InputControlMessage(const robosub::control::ConstPtr& msg);
     void InputOrientationMessage(
-            const robosub::QuaternionStampedAccuracy::ConstPtr& quat_msg);
+            const geometry_msgs::QuaternionStamped::ConstPtr& quat_msg);
     void InputLocalizationMessage(
             const geometry_msgs::Vector3::ConstPtr& vector_msg);
     void InputDepthMessage(const robosub::Float32Stamped::ConstPtr& depth_msg);

--- a/src/rqt/rqt_syscheck/src/rqt_syscheck/syscheck.py
+++ b/src/rqt/rqt_syscheck/src/rqt_syscheck/syscheck.py
@@ -19,7 +19,7 @@ from python_qt_binding.QtCore import QTimer
 # Import Messages
 from robosub.msg import thruster
 from robosub.msg import Float32Stamped
-from robosub.msg import QuaternionStampedAccuracy
+from geometry_msgs import QuaternionStamped
 
 class SysCheck(Plugin):
 
@@ -46,7 +46,7 @@ class SysCheck(Plugin):
         self.depth_sub = rospy.Subscriber('depth', Float32Stamped,
                                           self.depthSubCallback, queue_size=1)
         self.imu_sub = rospy.Subscriber('orientation',
-                                        QuaternionStampedAccuracy,
+                                        QuaternionStamped,
                                         self.imuSubCallback, queue_size=1)
 
         # Initialize the timers

--- a/src/sensors/trilateration.cpp
+++ b/src/sensors/trilateration.cpp
@@ -17,7 +17,7 @@
 
 #include "robosub/HydrophoneDeltas.h"
 #include "robosub/PositionArrayStamped.h"
-#include "robosub/QuaternionStampedAccuracy.h"
+#include "geometry_msgs/QuaternionStamped.h"
 #include "robosub/Float32Stamped.h"
 #include "geometry_msgs/Point.h"
 #include "ros/ros.h"
@@ -72,7 +72,7 @@ double zeta;
  * @return None.
  */
 void orientationCallback(const
-        robosub::QuaternionStampedAccuracy::ConstPtr& msg)
+        geometry_msgs::QuaternionStamped::ConstPtr& msg)
 {
     current_orientation = Quaterniond(msg->quaternion.w, msg->quaternion.x,
             msg->quaternion.y, msg->quaternion.z);


### PR DESCRIPTION
As per our discussion, this pull request removes occurrances of QuaternionStampedAccuracy in favor of the default QuaternionStamped. Accuracy information is now published on a separate topic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/255)
<!-- Reviewable:end -->
