### PR TITLE
Adds in support to joystick and gamepads for marker droppers and torpedoes

### DIFF
--- a/launch/joystick.launch
+++ b/launch/joystick.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node name="joystick_control" pkg="robosub" type="joystick_control" />
+    <node name="joystick_control" pkg="robosub" type="joystick_control" output="screen"/>
     <node name="joystick_driver" pkg="robosub" type="joystick_driver" />
     <rosparam command="load" file="$(find robosub)/param/joystick.yaml" />
 </launch>

--- a/src/controllers/gamepad_control.cpp
+++ b/src/controllers/gamepad_control.cpp
@@ -125,7 +125,8 @@ void gamepadToControlCallback(const robosub::gamepad msg)
         // Marker Droppers and Torpedos
         // buttons 2 (X) and 1 (Square) are arming buttons
         // RB and LB fire respective side
-        if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg) && msg.buttons[4])
+        if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg)
+                && msg.buttons[4])
         {
             // Fire left marker dropper
             ros::NodeHandle n;
@@ -141,7 +142,8 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop left marker");
             }
         }
-        else if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg) && msg.buttons[5])
+        else if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg)
+                && msg.buttons[5])
         {
             // Fire right marker dropper
             ros::NodeHandle n;
@@ -157,11 +159,13 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop right marker");
             }
         }
-        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg) && msg.buttons[4])
+        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg)
+                && msg.buttons[4])
         {
             // Fire left torpedo
         }
-        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg) && msg.buttons[5])
+        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg)
+                && msg.buttons[5])
         {
             // Fire right torpedo
         }
@@ -195,7 +199,8 @@ void gamepadToControlCallback(const robosub::gamepad msg)
         // Marker Droppers and Torpedos
         // buttons 13 (Circle) and 15 (Square) are arming buttons
         // R1 and L1 fire respective side
-        if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg) && msg.buttons[10])
+        if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg)
+                && msg.buttons[10])
         {
             // Fire left marker dropper
             ros::NodeHandle n;
@@ -211,7 +216,8 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop left marker");
             }
         }
-        else if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg) && msg.buttons[11])
+        else if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg)
+                && msg.buttons[11])
         {
             // Fire right marker dropper
             ros::NodeHandle n;
@@ -227,11 +233,13 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop right marker");
             }
         }
-        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg) && msg.buttons[10])
+        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg)
+                && msg.buttons[10])
         {
             // Fire left torpedo
         }
-        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg) && msg.buttons[11])
+        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg)
+                && msg.buttons[11])
         {
             // Fire right torpedo
         }

--- a/src/controllers/gamepad_control.cpp
+++ b/src/controllers/gamepad_control.cpp
@@ -91,6 +91,9 @@ void gamepadToControlCallback(const robosub::gamepad msg)
         outmsg.yaw_left = 0;
     }
 
+    ros::NodeHandle n;
+    ros::ServiceClient client = n.serviceClient<std_srvs::Empty>("drop_marker");
+    std_srvs::Empty e;
     // Using Xbox controller
     if (robosub::gamepad::XBOX == msg.type && !msg.buttons[8])
     {
@@ -122,10 +125,6 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 && msg.buttons[4])
         {
             // Fire left marker dropper
-            ros::NodeHandle n;
-            ros::ServiceClient client =
-                n.serviceClient<std_srvs::Empty>("drop_marker");
-            std_srvs::Empty e;
             if (client.call(e))
             {
                 ROS_INFO("Left Marker Dropped");
@@ -139,10 +138,6 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 && msg.buttons[5])
         {
             // Fire right marker dropper
-            ros::NodeHandle n;
-            ros::ServiceClient client =
-                n.serviceClient<std_srvs::Empty>("drop_marker");
-            std_srvs::Empty e;
             if (client.call(e))
             {
                 ROS_INFO("Right Marker Dropped");
@@ -196,10 +191,6 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 && msg.buttons[10])
         {
             // Fire left marker dropper
-            ros::NodeHandle n;
-            ros::ServiceClient client =
-                n.serviceClient<std_srvs::Empty>("drop_marker");
-            std_srvs::Empty e;
             if (client.call(e))
             {
                 ROS_INFO("Left Marker Dropped");
@@ -213,10 +204,6 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 && msg.buttons[11])
         {
             // Fire right marker dropper
-            ros::NodeHandle n;
-            ros::ServiceClient client =
-                n.serviceClient<std_srvs::Empty>("drop_marker");
-            std_srvs::Empty e;
             if (client.call(e))
             {
                 ROS_INFO("Right Marker Dropped");

--- a/src/controllers/gamepad_control.cpp
+++ b/src/controllers/gamepad_control.cpp
@@ -31,37 +31,30 @@ double dead_scale(double value, double deadzone, double scaling_power)
     return pow( num/(1-deadzone), scaling_power ) * sgn;
 }
 
-bool checkXBOXArmingAndTriggers(const robosub::gamepad msg)
+bool checkArmingAndTriggers(const robosub::gamepad msg)
 {
-    int armingButtonsPressed = static_cast<int>(msg.buttons[1])
+    int armingButtonsPressed = 0;
+    int triggersPressed = 0;
+    if (msg.type == robosub::gamepad::XBOX)
+    {
+        armingButtonsPressed = static_cast<int>(msg.buttons[1])
                             + static_cast<int>(msg.buttons[2]);
-    if (armingButtonsPressed > 1)
-    {
-        ROS_WARN("More than one arming button is pressed!!!!");
-    }
 
-    int triggersPressed = static_cast<int>(msg.buttons[4])
+        triggersPressed = static_cast<int>(msg.buttons[4])
                         + static_cast<int>(msg.buttons[5]);
-
-    if (triggersPressed > 1)
-    {
-        ROS_WARN("More than one firing trigger is pressed");
     }
-
-    return (armingButtonsPressed == 1) && (triggersPressed == 1);
-}
-
-bool checkPS3ArmingAndTriggers(const robosub::gamepad msg)
-{
-    int armingButtonsPressed = static_cast<int>(msg.buttons[13])
+    else if (msg.type == robosub::gamepad::PS3)
+    {
+        armingButtonsPressed = static_cast<int>(msg.buttons[13])
                             + static_cast<int>(msg.buttons[15]);
+
+        triggersPressed = static_cast<int>(msg.buttons[10])
+                        + static_cast<int>(msg.buttons[11]);
+    }
     if (armingButtonsPressed > 1)
     {
         ROS_WARN("More than one arming button is pressed!!!!");
     }
-
-    int triggersPressed = static_cast<int>(msg.buttons[10])
-                        + static_cast<int>(msg.buttons[11]);
 
     if (triggersPressed > 1)
     {
@@ -99,7 +92,7 @@ void gamepadToControlCallback(const robosub::gamepad msg)
     }
 
     // Using Xbox controller
-    if (robosub::gamepad::XBOX == msg.type && !msg.buttons[0])
+    if (robosub::gamepad::XBOX == msg.type && !msg.buttons[8])
     {
         if (msg.hatX)
         {
@@ -125,7 +118,7 @@ void gamepadToControlCallback(const robosub::gamepad msg)
         // Marker Droppers and Torpedos
         // buttons 2 (X) and 1 (Square) are arming buttons
         // RB and LB fire respective side
-        if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg)
+        if (msg.buttons[2] && checkArmingAndTriggers(msg)
                 && msg.buttons[4])
         {
             // Fire left marker dropper
@@ -142,7 +135,7 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop left marker");
             }
         }
-        else if (msg.buttons[2] && checkXBOXArmingAndTriggers(msg)
+        else if (msg.buttons[2] && checkArmingAndTriggers(msg)
                 && msg.buttons[5])
         {
             // Fire right marker dropper
@@ -159,12 +152,12 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop right marker");
             }
         }
-        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg)
+        else if (msg.buttons[1] && checkArmingAndTriggers(msg)
                 && msg.buttons[4])
         {
             // Fire left torpedo
         }
-        else if (msg.buttons[1] && checkXBOXArmingAndTriggers(msg)
+        else if (msg.buttons[1] && checkArmingAndTriggers(msg)
                 && msg.buttons[5])
         {
             // Fire right torpedo
@@ -199,7 +192,7 @@ void gamepadToControlCallback(const robosub::gamepad msg)
         // Marker Droppers and Torpedos
         // buttons 13 (Circle) and 15 (Square) are arming buttons
         // R1 and L1 fire respective side
-        if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg)
+        if (msg.buttons[15] && checkArmingAndTriggers(msg)
                 && msg.buttons[10])
         {
             // Fire left marker dropper
@@ -216,7 +209,7 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop left marker");
             }
         }
-        else if (msg.buttons[15] && checkPS3ArmingAndTriggers(msg)
+        else if (msg.buttons[15] && checkArmingAndTriggers(msg)
                 && msg.buttons[11])
         {
             // Fire right marker dropper
@@ -233,12 +226,12 @@ void gamepadToControlCallback(const robosub::gamepad msg)
                 ROS_WARN("Failed to drop right marker");
             }
         }
-        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg)
+        else if (msg.buttons[13] && checkArmingAndTriggers(msg)
                 && msg.buttons[10])
         {
             // Fire left torpedo
         }
-        else if (msg.buttons[13] && checkPS3ArmingAndTriggers(msg)
+        else if (msg.buttons[13] && checkArmingAndTriggers(msg)
                 && msg.buttons[11])
         {
             // Fire right torpedo

--- a/src/controllers/joystick_control.cpp
+++ b/src/controllers/joystick_control.cpp
@@ -101,13 +101,14 @@ void joystickToControlCallback(const robosub::joystick msg)
     // buttons 3-6 are arming buttons, trigger fires
     // 3 and 4 arm marker droppers, 5 and 6 arm torpedos
     // (Subtract one from button number to get array index)
+    ros::NodeHandle n;
+    ros::ServiceClient client =
+        n.serviceClient<std_srvs::Empty>("drop_marker");
+    std_srvs::Empty e;
+
     if (msg.buttons[2] && checkArming(msg) && msg.buttons[0])
     {
         // Fire left marker dropper
-        ros::NodeHandle n;
-        ros::ServiceClient client =
-            n.serviceClient<std_srvs::Empty>("drop_marker");
-        std_srvs::Empty e;
         if (client.call(e))
         {
             ROS_INFO("Left Marker Dropped");
@@ -120,10 +121,6 @@ void joystickToControlCallback(const robosub::joystick msg)
     else if (msg.buttons[3] && checkArming(msg) && msg.buttons[0])
     {
         // Fire right marker dropper
-        ros::NodeHandle n;
-        ros::ServiceClient client =
-            n.serviceClient<std_srvs::Empty>("drop_marker");
-        std_srvs::Empty e;
         if (client.call(e))
         {
             ROS_INFO("Right Marker Dropped");

--- a/src/controllers/keyboard_control.cpp
+++ b/src/controllers/keyboard_control.cpp
@@ -26,8 +26,8 @@ uint8_t getKey(void)
 
 void PrintHelp()
 {
-    std::cout << "There are two methods of control\n"
-                 "First way is:\n"
+    std::cout << "There are two control methods\n"
+                 "One method:\n"
                  "W -> forward\n"
                  "S -> backward\n"
                  "A -> strafe to the left\n"
@@ -40,7 +40,7 @@ void PrintHelp()
                  "E -> yaw right\n"
                  "L -> roll left\n"
                  "; -> roll right"
-                 "\n\n\nAlternative is with arrow keys:\n"
+                 "\n\n\nSecond method:\n"
                  "ArrowUp -> forward\n"
                  "ArrowDown -> backward\n"
                  "ArrowLeft -> strafe to the left\n"


### PR DESCRIPTION
The joystick uses the 4 buttons by the hat for arming the devices and the trigger to actually fire. Only one device can be armed at a time for safety.

The gamepads use a single button for arming a device type and the "bumpers" to determine right or left and to fire the device. Only one arming button and one firing button can be pressed at any time.

**FYI**
In each case the number of arming and firing buttons is checked to prevent multiple devices firing at the same time and warns the user is such a case arises. Torpedoes are not yet implemented for calling the service as the services don't exist yet. The marker droppers call the same "drop_marker" service a the moment as the right and left have yet to be separated. The keyboard controller has yet to implement these features and may never implement them due to the difficulty of capturing multiple keys pressed at the same time that are not special key combos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/256)
<!-- Reviewable:end -->
