### PR TITLE
Multiple IMU support

### DIFF
--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -147,45 +147,11 @@ bno055_left:
         x: 1
         y: 2
         z: 3
-    accelerometer:
-        offset:
-            x: 0
-            y: 0
-            z: 0
-        radius: 0
-    magnetometer:
-        offset:
-            x: 0
-            y: 0
-            z: 0
-        radius: 0
-    gyroscope:
-        offset:
-            x: 0
-            y: 0
-            z: 0
 bno055_right:
     axis:
         x: 1
         y: 2
         z: 3
-    accelerometer:
-        offset:
-            x: 0
-            y: 0
-            z: 0
-        radius: 0
-    magnetometer:
-        offset:
-            x: 0
-            y: 0
-            z: 0
-        radius: 0
-    gyroscope:
-        offset:
-            x: 0
-            y: 0
-            z: 0
 hydrophones:
     pinger:
         depth: -4.1

--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -1,15 +1,8 @@
 ports:
     thruster: "/dev/maestro_control"
-    bno055_left: "/dev/bno055_left"
-    bno055_right: "/dev/bno055_right"
-    trax: "/dev/trax"
 rate:
     control: 50
     depth: 10
-    imu: 20
-    bno055_left: 20
-    bno055_right: 20
-    trax: 20
     localization: 30
 thrusters:
     max_thrust: 24
@@ -143,15 +136,22 @@ control:
 depth:
     offset: 0.75
 bno055_left:
+    port: "/dev/bno055_left"
+    rate: 20
     axis:
         x: 1
         y: 2
         z: 3
 bno055_right:
+    port: "/dev/bno055_right"
+    rate: 20
     axis:
         x: 1
         y: 2
         z: 3
+trax:
+    port: "/dev/trax"
+    rate: 20
 hydrophones:
     pinger:
         depth: -4.1

--- a/param/cobalt.yaml
+++ b/param/cobalt.yaml
@@ -1,11 +1,15 @@
 ports:
     thruster: "/dev/maestro_control"
-    sensor: "/dev/bno055_right"
+    bno055_left: "/dev/bno055_left"
+    bno055_right: "/dev/bno055_right"
     trax: "/dev/trax"
 rate:
     control: 50
     depth: 10
     imu: 20
+    bno055_left: 20
+    bno055_right: 20
+    trax: 20
     localization: 30
 thrusters:
     max_thrust: 24
@@ -138,7 +142,29 @@ control:
     buoyancy_offset: -32.0
 depth:
     offset: 0.75
-sensor:
+bno055_left:
+    axis:
+        x: 1
+        y: 2
+        z: 3
+    accelerometer:
+        offset:
+            x: 0
+            y: 0
+            z: 0
+        radius: 0
+    magnetometer:
+        offset:
+            x: 0
+            y: 0
+            z: 0
+        radius: 0
+    gyroscope:
+        offset:
+            x: 0
+            y: 0
+            z: 0
+bno055_right:
     axis:
         x: 1
         y: 2

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ros_node(bno055_calibrate bno055_calibration.cpp)
 target_link_libraries(bno055_calibrate serial bno055)
 
 add_ros_node(imu imu.cpp)
-target_link_libraries(imu serial)
 
 add_ros_node(depth depth.cpp)
 target_link_libraries(depth serial)

--- a/src/sensors/bno055_calibration.cpp
+++ b/src/sensors/bno055_calibration.cpp
@@ -39,10 +39,14 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "sensor_calibration");
     ros::Time::init();
-    string port_name;
+    string node_name = ros::this_node::getName();
 
-    HandleError(ros::param::get("/ports/sensor", port_name) == false,
-            "ros::param::get(\"/ports/sensor\")", true);
+
+    string port_name;
+    string port_param_name = "ports/" + node_name;
+    HandleError(ros::param::get(port_param_name, port_name) == false,
+            ("ros::param::get(\"" + port_param_name + "\")").c_str(),
+            true);
 
     Bno055 bno;
 

--- a/src/sensors/bno055_calibration.cpp
+++ b/src/sensors/bno055_calibration.cpp
@@ -37,16 +37,12 @@ void HandleError(int x, const char * s, bool abort = false)
  */
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "sensor_calibration");
+    ros::init(argc, argv, "bno055");
     ros::Time::init();
-    string node_name = ros::this_node::getName();
-
 
     string port_name;
-    string port_param_name = "ports/" + node_name;
-    HandleError(ros::param::get(port_param_name, port_name) == false,
-            ("ros::param::get(\"" + port_param_name + "\")").c_str(),
-            true);
+    HandleError(ros::param::get("~port", port_name) == false,
+                "ros::param::get()", true);
 
     Bno055 bno;
 

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -150,29 +150,27 @@ int main(int argc, char **argv)
     /*
      * Construct a node handle for communicating with ROS.
      */
-    ros::NodeHandle nh("~");
-
-    std::string node_name = ros::this_node::getName();
+    ros::NodeHandle np("~");
 
     /*
      * Advertise the stamped quaternion and acceleration sensor
      * data to the software and the trim service call.
      */
     quaternion_publisher =
-            nh.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
+            np.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
     linear_acceleration_publisher =
-        nh.advertise<geometry_msgs::Vector3Stamped>("acceleration/linear", 1);
-    euler_publisher = nh.advertise<robosub::Euler>("pretty/orientation", 1);
-    info_publisher = nh.advertise<std_msgs::String>("info", 1);
-    ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
-    ros::ServiceServer mode_service = nh.advertiseService("set_mode", set_mode);
+        np.advertise<geometry_msgs::Vector3Stamped>("acceleration/linear", 1);
+    euler_publisher = np.advertise<robosub::Euler>("pretty/orientation", 1);
+    info_publisher = np.advertise<std_msgs::String>("info", 1);
+    ros::ServiceServer trim_service = np.advertiseService("trim", trim);
+    ros::ServiceServer mode_service = np.advertiseService("set_mode", set_mode);
 
     /*
      * Create the serial port, initialize it, and hand it to the Bno055 sensor
      * class.
      */
     std::string port_name;
-    FatalAbortIf(nh.getParam("port", port_name) == false,
+    FatalAbortIf(np.getParam("port", port_name) == false,
                  "Failed to get port name parameter");
     FatalAbortIf(sensor.init(port_name) != 0, "Bno055 failed to initialize");
     ROS_INFO("Sensor successfully initialized.");
@@ -196,39 +194,39 @@ int main(int argc, char **argv)
      */
     bool failed_radii_load = false, failed_offset_load = false,
             failed_axis_load = false;
-    ROS_WARN_COND(nh.getParam("accelerometer/radius",
+    ROS_WARN_COND(np.getParam("accelerometer/radius",
             accelerometer_radius) == false && (failed_radii_load = true),
             "Failed to load accelerometer calibration radius.");
-    ROS_WARN_COND(nh.getParam("accelerometer/offset/x",
+    ROS_WARN_COND(np.getParam("accelerometer/offset/x",
             accelerometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParam("accelerometer/offset/y",
+    ROS_WARN_COND(np.getParam("accelerometer/offset/y",
             accelerometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParam("accelerometer/offset/z",
+    ROS_WARN_COND(np.getParam("accelerometer/offset/z",
             accelerometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParam("magnetometer/radius",
+    ROS_WARN_COND(np.getParam("magnetometer/radius",
             magnetometer_radius) == false && (failed_radii_load = true),
             "Failed to load magnetometer calibration radius.");
-    ROS_WARN_COND(nh.getParam("magnetometer/offset/x",
+    ROS_WARN_COND(np.getParam("magnetometer/offset/x",
             magnetometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParam("magnetometer/offset/y",
+    ROS_WARN_COND(np.getParam("magnetometer/offset/y",
             magnetometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParam("magnetometer/offset/z",
+    ROS_WARN_COND(np.getParam("magnetometer/offset/z",
             magnetometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParam("gyroscope/offset/x",
+    ROS_WARN_COND(np.getParam("gyroscope/offset/x",
             gyroscope_offset[0]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParam("gyroscope/offset/y",
+    ROS_WARN_COND(np.getParam("gyroscope/offset/y",
             gyroscope_offset[1]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParam("gyroscope/offset/z",
+    ROS_WARN_COND(np.getParam("gyroscope/offset/z",
             gyroscope_offset[2]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
 
@@ -239,13 +237,13 @@ int main(int argc, char **argv)
      * the negative direction.
      */
     int axis_x, axis_y, axis_z;
-    ROS_WARN_COND(nh.getParam("axis/x", axis_x) == false &&
+    ROS_WARN_COND(np.getParam("axis/x", axis_x) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped X axis.");
-    ROS_WARN_COND(nh.getParam("axis/y", axis_y) == false &&
+    ROS_WARN_COND(np.getParam("axis/y", axis_y) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Y axis.");
-    ROS_WARN_COND(nh.getParam("axis/z", axis_z) == false &&
+    ROS_WARN_COND(np.getParam("axis/z", axis_z) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Z axis.");
 
@@ -298,7 +296,7 @@ int main(int argc, char **argv)
      * Enter the main ROS loop.
      */
     int rate;
-    if (!nh.getParam("rate", rate))
+    if (!np.getParam("rate", rate))
     {
         ROS_WARN("Failed to load rate. Falling back to 20Hz.");
         rate = 20;

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -33,7 +33,9 @@ double last_roll, last_pitch, trim_roll, trim_pitch;
  * Fatally exits if expression x evalutes true.
  *
  * @param x The expression to evaluate.
- * @param s The string to list when exitting.
+ * @param ... The format string to list when exitting, plus args.
+ *            This is similar to printf syntax.
+
  */
 #define FatalAbortIf(x, ...) { int ret = (x); if(ret) { ROS_FATAL(__VA_ARGS__); exit(-1); }}
 

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -149,28 +149,36 @@ int main(int argc, char **argv)
      */
     ros::NodeHandle nh;
 
+    std::string node_name = ros::this_node::getName();
+
     /*
      * Advertise the stamped quaternion and acceleration sensor
      * data to the software and the trim service call.
      */
     quaternion_publisher =
-            nh.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
+            nh.advertise<geometry_msgs::QuaternionStamped>(
+            node_name + "/orientation", 1);
     linear_acceleration_publisher =
-        nh.advertise<geometry_msgs::Vector3Stamped>("acceleration/linear", 1);
-    euler_publisher = nh.advertise<robosub::Euler>("pretty/orientation", 1);
-    info_publisher = nh.advertise<std_msgs::String>("info/bno055", 1);
-    ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
-    ros::ServiceServer mode_service = nh.advertiseService("set_bno_mode",
-            set_mode);
+        nh.advertise<geometry_msgs::Vector3Stamped>(
+        node_name + "/acceleration/linear", 1);
+    euler_publisher = nh.advertise<robosub::Euler>(
+            node_name + "/pretty/orientation", 1);
+    info_publisher = nh.advertise<std_msgs::String>(
+            node_name + "/info/bno055", 1);
+    ros::ServiceServer trim_service = nh.advertiseService(
+            node_name + "/trim", trim);
+    ros::ServiceServer mode_service = nh.advertiseService(
+            node_name + "/set_mode", set_mode);
 
     /*
      * Create the serial port, initialize it, and hand it to the Bno055 sensor
      * class.
      */
     std::string port_name;
-    std::string port_param = "ports" + ros::this_node::getName();
-    FatalAbortIf(ros::param::get(port_param, port_name) == false,
-            "Failed to get port name parameter: \"%s\"", port_param.c_str());
+    std::string port_param_name = "ports/" + node_name;
+    FatalAbortIf(ros::param::get(port_param_name, port_name) == false,
+            "Failed to get port name parameter: \"%s\"",
+            port_param_name.c_str());
     FatalAbortIf(sensor.init(port_name) != 0, "Bno055 failed to initialize");
     ROS_INFO("Sensor successfully initialized.");
 
@@ -193,39 +201,39 @@ int main(int argc, char **argv)
      */
     bool failed_radii_load = false, failed_offset_load = false,
             failed_axis_load = false;
-    ROS_WARN_COND(nh.getParamCached("sensor/accelerometer/radius",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/radius",
             accelerometer_radius) == false && (failed_radii_load = true),
             "Failed to load accelerometer calibration radius.");
-    ROS_WARN_COND(nh.getParamCached("sensor/accelerometer/offset/x",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/x",
             accelerometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/accelerometer/offset/y",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/y",
             accelerometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/accelerometer/offset/z",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/z",
             accelerometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParamCached("sensor/magnetometer/radius",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/radius",
             magnetometer_radius) == false && (failed_radii_load = true),
             "Failed to load magnetometer calibration radius.");
-    ROS_WARN_COND(nh.getParamCached("sensor/magnetometer/offset/x",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/x",
             magnetometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/magnetometer/offset/y",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/y",
             magnetometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/magnetometer/offset/z",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/z",
             magnetometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParamCached("sensor/gyroscope/offset/x",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/x",
             gyroscope_offset[0]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/gyroscope/offset/y",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/y",
             gyroscope_offset[1]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParamCached("sensor/gyroscope/offset/z",
+    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/z",
             gyroscope_offset[2]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
 
@@ -236,13 +244,13 @@ int main(int argc, char **argv)
      * the negative direction.
      */
     int axis_x, axis_y, axis_z;
-    ROS_WARN_COND(nh.getParamCached("sensor/axis/x", axis_x) == false &&
+    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/x", axis_x) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped X axis.");
-    ROS_WARN_COND(nh.getParamCached("sensor/axis/y", axis_y) == false &&
+    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/y", axis_y) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Y axis.");
-    ROS_WARN_COND(nh.getParamCached("sensor/axis/z", axis_z) == false &&
+    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/z", axis_z) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Z axis.");
 
@@ -295,9 +303,11 @@ int main(int argc, char **argv)
      * Enter the main ROS loop.
      */
     int rate;
-    if (!nh.getParam("rate/imu", rate))
+    std::string rate_param = "rate/" + node_name;
+    if (!nh.getParam(rate_param, rate))
     {
-        ROS_WARN("Failed to load BNO055 node rate. Falling back to 20Hz.");
+        ROS_WARN("Failed to load \"%s\". Falling back to 20Hz.",
+                 rate_param.c_str());
         rate = 20;
     }
     ros::Rate r(rate);

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -37,7 +37,8 @@ double last_roll, last_pitch, trim_roll, trim_pitch;
  *            This is similar to printf syntax.
 
  */
-#define FatalAbortIf(x, ...) { int ret = (x); if(ret) { ROS_FATAL(__VA_ARGS__); exit(-1); }}
+#define FatalAbortIf(x, ...) { int ret = (x); if(ret) \
+    { ROS_FATAL(__VA_ARGS__); exit(-1); }}
 
 /**
  * Encodes an axis integral value into the Bno055::Axis type.
@@ -149,7 +150,7 @@ int main(int argc, char **argv)
     /*
      * Construct a node handle for communicating with ROS.
      */
-    ros::NodeHandle nh;
+    ros::NodeHandle nh("~");
 
     std::string node_name = ros::this_node::getName();
 
@@ -158,29 +159,21 @@ int main(int argc, char **argv)
      * data to the software and the trim service call.
      */
     quaternion_publisher =
-            nh.advertise<geometry_msgs::QuaternionStamped>(
-            node_name + "/orientation", 1);
+            nh.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
     linear_acceleration_publisher =
-        nh.advertise<geometry_msgs::Vector3Stamped>(
-        node_name + "/acceleration/linear", 1);
-    euler_publisher = nh.advertise<robosub::Euler>(
-            node_name + "/pretty/orientation", 1);
-    info_publisher = nh.advertise<std_msgs::String>(
-            node_name + "/info/bno055", 1);
-    ros::ServiceServer trim_service = nh.advertiseService(
-            node_name + "/trim", trim);
-    ros::ServiceServer mode_service = nh.advertiseService(
-            node_name + "/set_mode", set_mode);
+        nh.advertise<geometry_msgs::Vector3Stamped>("acceleration/linear", 1);
+    euler_publisher = nh.advertise<robosub::Euler>("pretty/orientation", 1);
+    info_publisher = nh.advertise<std_msgs::String>("info/bno055", 1);
+    ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
+    ros::ServiceServer mode_service = nh.advertiseService("set_mode", set_mode);
 
     /*
      * Create the serial port, initialize it, and hand it to the Bno055 sensor
      * class.
      */
     std::string port_name;
-    std::string port_param_name = "ports/" + node_name;
-    FatalAbortIf(ros::param::get(port_param_name, port_name) == false,
-            "Failed to get port name parameter: \"%s\"",
-            port_param_name.c_str());
+    FatalAbortIf(nh.getParam("port", port_name) == false,
+                 "Failed to get port name parameter");
     FatalAbortIf(sensor.init(port_name) != 0, "Bno055 failed to initialize");
     ROS_INFO("Sensor successfully initialized.");
 
@@ -203,39 +196,39 @@ int main(int argc, char **argv)
      */
     bool failed_radii_load = false, failed_offset_load = false,
             failed_axis_load = false;
-    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/radius",
+    ROS_WARN_COND(nh.getParam("accelerometer/radius",
             accelerometer_radius) == false && (failed_radii_load = true),
             "Failed to load accelerometer calibration radius.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/x",
+    ROS_WARN_COND(nh.getParam("accelerometer/offset/x",
             accelerometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/y",
+    ROS_WARN_COND(nh.getParam("accelerometer/offset/y",
             accelerometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/accelerometer/offset/z",
+    ROS_WARN_COND(nh.getParam("accelerometer/offset/z",
             accelerometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load accelerometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/radius",
+    ROS_WARN_COND(nh.getParam("magnetometer/radius",
             magnetometer_radius) == false && (failed_radii_load = true),
             "Failed to load magnetometer calibration radius.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/x",
+    ROS_WARN_COND(nh.getParam("magnetometer/offset/x",
             magnetometer_offset[0]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/y",
+    ROS_WARN_COND(nh.getParam("magnetometer/offset/y",
             magnetometer_offset[1]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/magnetometer/offset/z",
+    ROS_WARN_COND(nh.getParam("magnetometer/offset/z",
             magnetometer_offset[2]) == false && (failed_offset_load = true),
             "Failed to load magnetometer calibration offset.");
 
-    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/x",
+    ROS_WARN_COND(nh.getParam("gyroscope/offset/x",
             gyroscope_offset[0]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/y",
+    ROS_WARN_COND(nh.getParam("gyroscope/offset/y",
             gyroscope_offset[1]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/gyroscope/offset/z",
+    ROS_WARN_COND(nh.getParam("gyroscope/offset/z",
             gyroscope_offset[2]) == false && (failed_offset_load = true),
             "Failed to load gyroscope calibration offset.");
 
@@ -246,13 +239,13 @@ int main(int argc, char **argv)
      * the negative direction.
      */
     int axis_x, axis_y, axis_z;
-    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/x", axis_x) == false &&
+    ROS_WARN_COND(nh.getParam("axis/x", axis_x) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped X axis.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/y", axis_y) == false &&
+    ROS_WARN_COND(nh.getParam("axis/y", axis_y) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Y axis.");
-    ROS_WARN_COND(nh.getParamCached(node_name + "/axis/z", axis_z) == false &&
+    ROS_WARN_COND(nh.getParam("axis/z", axis_z) == false &&
             (failed_axis_load = true),
             "Failed to load Bno055 remapped Z axis.");
 
@@ -305,11 +298,9 @@ int main(int argc, char **argv)
      * Enter the main ROS loop.
      */
     int rate;
-    std::string rate_param = "rate/" + node_name;
-    if (!nh.getParam(rate_param, rate))
+    if (!nh.getParam("rate", rate))
     {
-        ROS_WARN("Failed to load \"%s\". Falling back to 20Hz.",
-                 rate_param.c_str());
+        ROS_WARN("Failed to load rate. Falling back to 20Hz.");
         rate = 20;
     }
     ros::Rate r(rate);

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
     linear_acceleration_publisher =
         nh.advertise<geometry_msgs::Vector3Stamped>("acceleration/linear", 1);
     euler_publisher = nh.advertise<robosub::Euler>("pretty/orientation", 1);
-    info_publisher = nh.advertise<std_msgs::String>("info/bno055", 1);
+    info_publisher = nh.advertise<std_msgs::String>("info", 1);
     ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
     ros::ServiceServer mode_service = nh.advertiseService("set_mode", set_mode);
 

--- a/src/sensors/bno055_sensor.cpp
+++ b/src/sensors/bno055_sensor.cpp
@@ -35,7 +35,7 @@ double last_roll, last_pitch, trim_roll, trim_pitch;
  * @param x The expression to evaluate.
  * @param s The string to list when exitting.
  */
-#define FatalAbortIf(x, s) { int ret = (x); if(ret) { ROS_FATAL(s); exit(-1); }}
+#define FatalAbortIf(x, ...) { int ret = (x); if(ret) { ROS_FATAL(__VA_ARGS__); exit(-1); }}
 
 /**
  * Encodes an axis integral value into the Bno055::Axis type.
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
     /*
      * Initialize ROS for this node.
      */
-    ros::init(argc, argv, "sensor");
+    ros::init(argc, argv, "bno055");
 
     /*
      * Construct a node handle for communicating with ROS.
@@ -168,8 +168,9 @@ int main(int argc, char **argv)
      * class.
      */
     std::string port_name;
-    FatalAbortIf(ros::param::get("ports/sensor", port_name) == false,
-            "Failed to get port name parameter.");
+    std::string port_param = "ports" + ros::this_node::getName();
+    FatalAbortIf(ros::param::get(port_param, port_name) == false,
+            "Failed to get port name parameter: \"%s\"", port_param.c_str());
     FatalAbortIf(sensor.init(port_name) != 0, "Bno055 failed to initialize");
     ROS_INFO("Sensor successfully initialized.");
 

--- a/src/sensors/imu.cpp
+++ b/src/sensors/imu.cpp
@@ -2,6 +2,7 @@
 #include "geometry_msgs/QuaternionStamped.h"
 #include "robosub/Euler.h"
 #include "tf/transform_datatypes.h"
+#include <string>
 
 ros::Publisher quaternion_publisher;
 ros::Publisher euler_publisher;

--- a/src/sensors/imu.cpp
+++ b/src/sensors/imu.cpp
@@ -1,16 +1,55 @@
 #include "ros/ros.h"
+#include "geometry_msgs/QuaternionStamped.h"
+#include "robosub/Euler.h"
+#include "tf/transform_datatypes.h"
 
-ros::Publisher pub;
+ros::Publisher quaternion_publisher;
+ros::Publisher euler_publisher;
+
+robosub::Euler quaternion_to_euler(
+                         const geometry_msgs::QuaternionStamped::ConstPtr &msg)
+{
+    double roll, pitch, yaw;
+    tf::Quaternion tf_quaternion;
+    robosub::Euler euler_msg;
+
+    tf::quaternionMsgToTF(msg->quaternion, tf_quaternion);
+
+    tf::Matrix3x3 m(tf_quaternion);
+    m.getRPY(roll, pitch, yaw);
+
+    euler_msg.roll = roll;
+    euler_msg.pitch = pitch;
+    euler_msg.yaw = yaw;
+
+    return euler_msg;
+}
+
+void orientation_callback(const geometry_msgs::QuaternionStamped::ConstPtr &msg)
+{
+    quaternion_publisher.publish(msg);
+    euler_publisher.publish(quaternion_to_euler(msg));
+}
 
 int main(int argc, char **argv)
 {
-
     ros::init(argc, argv, "imu");
 
     ros::NodeHandle n;
 
-    ROS_INFO_STREAM("name: " << ros::this_node::getName());
-    ROS_INFO_STREAM("namespace: " << ros::this_node::getNamespace());
+    std::string active_imu;
+    if(ros::param::get("~active_imu", active_imu) != true)
+    {
+        ROS_FATAL("~active_imu param not set.");
+        return 1;
+    }
+
+    quaternion_publisher =
+            n.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
+    euler_publisher = n.advertise<robosub::Euler>("pretty/orientation", 1);
+
+    ros::Subscriber sub = n.subscribe(active_imu + "/orientation", 1,
+                                      orientation_callback);
 
     ros::spin();
 

--- a/src/sensors/imu.cpp
+++ b/src/sensors/imu.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include "tf/transform_datatypes.h"
 
+#define _180_OVER_PI (180.0 / 3.14159)
+
 ros::Publisher quaternion_publisher;
 ros::Publisher euler_publisher;
 
@@ -19,9 +21,9 @@ robosub::Euler quaternion_to_euler(
     tf::Matrix3x3 m(tf_quaternion);
     m.getRPY(roll, pitch, yaw);
 
-    euler_msg.roll = roll;
-    euler_msg.pitch = pitch;
-    euler_msg.yaw = yaw;
+    euler_msg.roll = roll * _180_OVER_PI;
+    euler_msg.pitch = pitch * _180_OVER_PI;
+    euler_msg.yaw = yaw * _180_OVER_PI;
 
     return euler_msg;
 }

--- a/src/sensors/imu.cpp
+++ b/src/sensors/imu.cpp
@@ -1,8 +1,8 @@
-#include "ros/ros.h"
 #include "geometry_msgs/QuaternionStamped.h"
 #include "robosub/Euler.h"
-#include "tf/transform_datatypes.h"
+#include "ros/ros.h"
 #include <string>
+#include "tf/transform_datatypes.h"
 
 ros::Publisher quaternion_publisher;
 ros::Publisher euler_publisher;

--- a/src/sensors/imu.cpp
+++ b/src/sensors/imu.cpp
@@ -1,11 +1,18 @@
 #include "ros/ros.h"
-#include "utility/serial.hpp"
 
-using namespace rs;
+ros::Publisher pub;
 
 int main(int argc, char **argv)
 {
-    Serial s;
+
+    ros::init(argc, argv, "imu");
+
+    ros::NodeHandle n;
+
+    ROS_INFO_STREAM("name: " << ros::this_node::getName());
+    ROS_INFO_STREAM("namespace: " << ros::this_node::getNamespace());
+
+    ros::spin();
 
     return 0;
 }

--- a/src/sensors/trax_calibration.cpp
+++ b/src/sensors/trax_calibration.cpp
@@ -66,13 +66,13 @@ int main(int argc, char *argv[])
 {
     ros::init(argc, argv, "trax");
 
-    ros::NodeHandle nh("~");
+    ros::NodeHandle np("~");
 
     /*
      * Load the serial port name from the parameter server.
      */
     std::string port_name;
-    ROS_FATAL_COND(nh.getParam("port", port_name) == false,
+    ROS_FATAL_COND(np.getParam("port", port_name) == false,
             "Failed to load TRAX serial port.");
 
     ROS_FATAL_COND(trax.init(port_name), "Failed to initialize TRAX sensor.");
@@ -80,15 +80,15 @@ int main(int argc, char *argv[])
     /*
      * Set up the server for the calibration points.
      */
-    ros::ServiceServer point_service = nh.advertiseService("calibrate",
+    ros::ServiceServer point_service = np.advertiseService("calibrate",
             take_calibration_point);
-    ros::ServiceServer save_service = nh.advertiseService("save", save);
+    ros::ServiceServer save_service = np.advertiseService("save", save);
 
     /*
      * Detect what type of calibration should be completed.
      */
     int type;
-    ROS_FATAL_COND(nh.getParam("type", type) == false,
+    ROS_FATAL_COND(np.getParam("type", type) == false,
             "Failed to load ~type for calibration type."
             "\n1 := FullRange,"
             "\n2 := 2-Dimensional"

--- a/src/sensors/trax_calibration.cpp
+++ b/src/sensors/trax_calibration.cpp
@@ -64,15 +64,15 @@ bool take_calibration_point(std_srvs::Empty::Request &req,
 
 int main(int argc, char *argv[])
 {
-    ros::init(argc, argv, "trax_calibration");
+    ros::init(argc, argv, "trax");
 
-    ros::NodeHandle nh;
+    ros::NodeHandle nh("~");
 
     /*
      * Load the serial port name from the parameter server.
      */
     std::string port_name;
-    ROS_FATAL_COND(nh.getParam("ports/trax", port_name) == false,
+    ROS_FATAL_COND(nh.getParam("port", port_name) == false,
             "Failed to load TRAX serial port.");
 
     ROS_FATAL_COND(trax.init(port_name), "Failed to initialize TRAX sensor.");
@@ -80,16 +80,15 @@ int main(int argc, char *argv[])
     /*
      * Set up the server for the calibration points.
      */
-    ros::ServiceServer point_service = nh.advertiseService("trax/calibrate",
+    ros::ServiceServer point_service = nh.advertiseService("calibrate",
             take_calibration_point);
-    ros::ServiceServer save_service = nh.advertiseService("trax/save", save);
+    ros::ServiceServer save_service = nh.advertiseService("save", save);
 
     /*
      * Detect what type of calibration should be completed.
      */
-    ros::NodeHandle np("~");
     int type;
-    ROS_FATAL_COND(np.getParam("type", type) == false,
+    ROS_FATAL_COND(nh.getParam("type", type) == false,
             "Failed to load ~type for calibration type."
             "\n1 := FullRange,"
             "\n2 := 2-Dimensional"

--- a/src/sensors/trax_sensor.cpp
+++ b/src/sensors/trax_sensor.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 {
     ros::init(argc, argv, "trax");
 
-    ros::NodeHandle nh("~");
+    ros::NodeHandle np("~");
 
     PniTrax imu;
 
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
      * Initialize the TRAX IMU.
      */
     std::string port_name;
-    ROS_FATAL_COND(nh.getParam("port", port_name) == false,
+    ROS_FATAL_COND(np.getParam("port", port_name) == false,
                    "Failed to load TRAX serial port.");
 
     if (imu.init(port_name, PniTrax::Mode::AHRS) != 0)
@@ -63,17 +63,17 @@ int main(int argc, char *argv[])
     /*
      * Set up the trim service and data publisher.
      */
-    ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
+    ros::ServiceServer trim_service = np.advertiseService("trim", trim);
 
     ros::Publisher trax_publisher =
-              nh.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
+              np.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
     ros::Publisher trax_pretty_publisher =
-                         nh.advertise<robosub::Euler>("pretty/orientation", 1);
+                         np.advertise<robosub::Euler>("pretty/orientation", 1);
     ros::Publisher trax_info_publisher =
-                                     nh.advertise<std_msgs::String>("info", 1);
+                                     np.advertise<std_msgs::String>("info", 1);
 
     float rate;
-    if (nh.getParam("rate", rate) == false)
+    if (np.getParam("rate", rate) == false)
     {
         ROS_WARN("Failed to load TRAX rate. Falling back to 20 Hz.");
         rate = 20;

--- a/src/sensors/trax_sensor.cpp
+++ b/src/sensors/trax_sensor.cpp
@@ -43,19 +43,16 @@ int main(int argc, char *argv[])
 {
     ros::init(argc, argv, "trax");
 
-    ros::NodeHandle nh;
+    ros::NodeHandle nh("~");
 
     PniTrax imu;
-
-    std::string node_name = ros::this_node::getName();
 
     /*
      * Initialize the TRAX IMU.
      */
     std::string port_name;
-    std::string port_param_name = "ports/" + node_name;
-    ROS_FATAL_COND(nh.getParam(port_param_name, port_name) == false,
-            "Failed to load TRAX serial port (%s)", port_param_name.c_str());
+    ROS_FATAL_COND(nh.getParam("port", port_name) == false,
+                   "Failed to load TRAX serial port.");
 
     if (imu.init(port_name, PniTrax::Mode::AHRS) != 0)
     {
@@ -66,23 +63,19 @@ int main(int argc, char *argv[])
     /*
      * Set up the trim service and data publisher.
      */
-    ros::ServiceServer trim_service = nh.advertiseService(node_name + "/trim",
-                                                          trim);
+    ros::ServiceServer trim_service = nh.advertiseService("trim", trim);
 
     ros::Publisher trax_publisher =
-            nh.advertise<geometry_msgs::QuaternionStamped>(
-            node_name + "/orientation", 1);
+              nh.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
     ros::Publisher trax_pretty_publisher =
-            nh.advertise<robosub::Euler>(node_name + "/pretty/orientation", 1);
+                         nh.advertise<robosub::Euler>("pretty/orientation", 1);
     ros::Publisher trax_info_publisher =
-            nh.advertise<std_msgs::String>(node_name + "/info", 1);
+                                     nh.advertise<std_msgs::String>("info", 1);
 
     float rate;
-    std::string rate_param_name = "rate/" + node_name;
-    if (nh.getParam(rate_param_name, rate) == false)
+    if (nh.getParam("rate", rate) == false)
     {
-        ROS_WARN("Failed to load TRAX rate (%s)."
-                 "Falling back to 20 Hz.", rate_param_name.c_str());
+        ROS_WARN("Failed to load TRAX rate. Falling back to 20 Hz.");
         rate = 20;
     }
 

--- a/src/sensors/trax_sensor.cpp
+++ b/src/sensors/trax_sensor.cpp
@@ -66,11 +66,11 @@ int main(int argc, char *argv[])
     ros::ServiceServer trim_service = np.advertiseService("trim", trim);
 
     ros::Publisher trax_publisher =
-              np.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
+            np.advertise<geometry_msgs::QuaternionStamped>("orientation", 1);
     ros::Publisher trax_pretty_publisher =
-                         np.advertise<robosub::Euler>("pretty/orientation", 1);
+            np.advertise<robosub::Euler>("pretty/orientation", 1);
     ros::Publisher trax_info_publisher =
-                                     np.advertise<std_msgs::String>("info", 1);
+            np.advertise<std_msgs::String>("info", 1);
 
     float rate;
     if (np.getParam("rate", rate) == false)


### PR DESCRIPTION
Both the TRAX and BNO055  nodes now publish to topics (and load parameters) underneath their node name. The IMU node must be launched in addition to one of the other nodes to publish to `/orientation` and `/pretty/orientation`.

Also updated simulator to support these changes, see PalouseRobosub/robosub_simulator#95

Implements #258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/262)
<!-- Reviewable:end -->
