### PR TITLE
updated IMU orientation

### DIFF
--- a/src/sensors/PniTrax.cpp
+++ b/src/sensors/PniTrax.cpp
@@ -121,7 +121,7 @@ int PniTrax::init(const string serial_port_name, Mode mode)
      * Set the TRAX's mounting orientation
      */
     data[0] = static_cast<uint8_t>(Config::kMountingRef);
-    data[1] = static_cast<uint8_t>(Mounting::x_up_270);
+    data[1] = static_cast<uint8_t>(Mounting::std_0);
     if (write_command(Command::kSetConfig, data, 2))
     {
         return -1;

--- a/src/sensors/PniTrax.h
+++ b/src/sensors/PniTrax.h
@@ -86,6 +86,7 @@ public:
 
     enum class Mounting : uint8_t
     {
+        std_0 = 1,
         x_up_270 = 10
     };
 


### PR DESCRIPTION
Needs testing. I believe the BNO055 orientations shouldn't have changed, pls confirm? Also, we should verify that the left/right labels for the BNO055s are still correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/268)
<!-- Reviewable:end -->
