### PR TITLE
control system test fix

### DIFF
--- a/src/movement/test/CMakeLists.txt
+++ b/src/movement/test/CMakeLists.txt
@@ -13,5 +13,7 @@ target_link_libraries(test_thruster_sabertooth serial test_tools ${catkin_LIBRAR
 add_rostest_gtest(test_control_system
   control_system.test
   test_control_system.cpp)
-add_dependencies(test_control_system control)
+add_dependencies(test_control_system control test_control_keep_alive)
 target_link_libraries(test_control_system test_tools ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+
+add_ros_node(test_control_keep_alive test_control_keep_alive.cpp)

--- a/src/movement/test/control_system.test
+++ b/src/movement/test/control_system.test
@@ -3,6 +3,8 @@
 
     <rosparam command="load" file="$(find robosub)/param/cobalt.yaml" />
 
+    <node pkg="robosub" type="test_control_keep_alive" name="control_keep_alive"/>
+
     <include file="$(find robosub_simulator)/launch/gazebo.launch">
         <arg name="gui" value="false"/>
     </include>

--- a/src/movement/test/test_control_keep_alive.cpp
+++ b/src/movement/test/test_control_keep_alive.cpp
@@ -1,0 +1,32 @@
+#include "ros/ros.h"
+#include "robosub/control.h"
+
+ros::Publisher pub;
+
+int main(int argc, char *argv[])
+{
+    ros::init(argc, argv, "control_system_keep_alive");
+    ros::NodeHandle n;
+
+    pub = n.advertise<robosub::control>("control", 1);
+
+    robosub::control msg;
+
+    // fill out empty control message
+    msg.forward_state = robosub::control::STATE_NONE;
+    msg.strafe_state = robosub::control::STATE_NONE;
+    msg.yaw_state = robosub::control::STATE_NONE;
+    msg.dive_state = robosub::control::STATE_NONE;
+    msg.pitch_state = robosub::control::STATE_NONE;
+    msg.roll_state = robosub::control::STATE_NONE;
+
+    ros::Rate r(3);
+
+    while (ros::ok())
+    {
+        pub.publish(msg);
+        r.sleep();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
When the control system was updated a few weeks ago to time out when it hasn't received a message in a while it broke the control system unit test. This PR adds a dummy node that sends empty control messages to keep the control system alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/295)
<!-- Reviewable:end -->
