### PR TITLE
fixed blind_movement bug

### DIFF
--- a/src/ai/blind_movement.py
+++ b/src/ai/blind_movement.py
@@ -12,6 +12,10 @@ class move_forward(smach.State):
         self.value = value
         self._poll_rate = rospy.Rate(poll_rate)
 
+        # wait for time to be non-zero
+        while(rospy.Time.now() == rospy.Time(0)):
+            rospy.sleep(1.0/self.poll_rate)
+
     def execute(self, userdata):
         c = control_wrapper()
         c.levelOut()


### PR DESCRIPTION
Props to Mike for noticing the bug. Simulator spits out time=0 upon startup,
need to wait for a non-zero time before doing any timing calculations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/306)
<!-- Reviewable:end -->
