### PR TITLE
Change out-of-date particle_filter.cpp pinger depth param location

### DIFF
--- a/src/localization/particle_filter.cpp
+++ b/src/localization/particle_filter.cpp
@@ -101,7 +101,7 @@ void ParticleFilter::initialize()
         ros::shutdown();
     }
 
-    if(!ros::param::has("hydrophones/pinger/depth"))
+    if(!ros::param::has("localization/pinger/depth"))
     {
         ROS_FATAL("pinger depth failed to load");
         ros::shutdown();


### PR DESCRIPTION
PR #307 missed updating one of parameter references to point at the new namespace/location for the pinger depth, as seen in #315.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/316)
<!-- Reviewable:end -->
