### PR TITLE
Unified localization and sub_tf_broadcaster to prevent conflicting tf frame data for cobalt

### DIFF
--- a/src/localization/localization_system.cpp
+++ b/src/localization/localization_system.cpp
@@ -132,29 +132,4 @@ void LocalizationSystem::Update()
     {
         sensors.InputPosition(particle_filter.GetPosition());
     }
-
-    tf::Vector3 pos = particle_filter.GetPosition();
-    publish_tf_message(pos);
-}
-
-void LocalizationSystem::publish_tf_message(tf::Vector3 pos)
-{
-    tf2_msgs::TFMessage tm;
-
-    geometry_msgs::TransformStamped robosub_transform;
-
-    robosub_transform.header.frame_id = "world";
-    robosub_transform.header.stamp = ros::Time::now();
-    robosub_transform.child_frame_id = "cobalt";
-
-    robosub_transform.transform.translation.x = pos[0];
-    robosub_transform.transform.translation.y = pos[1];
-    robosub_transform.transform.translation.z = pos[2];
-    robosub_transform.transform.rotation.x = 0.0;
-    robosub_transform.transform.rotation.y = 0.0;
-    robosub_transform.transform.rotation.z = 0.0;
-    robosub_transform.transform.rotation.w = 1.0;
-
-    tm.transforms.push_back(robosub_transform);
-    transform_pub.publish(tm);
 }

--- a/src/sensors/sub_tf_broadcaster.py
+++ b/src/sensors/sub_tf_broadcaster.py
@@ -3,7 +3,7 @@
 import rospy
 import tf
 import tf2_ros
-from geometry_msgs.msg import (QuaternionStamped, TransformStamped, 
+from geometry_msgs.msg import (QuaternionStamped, TransformStamped,
     Quaternion, PointStamped, Point)
 from robosub.msg import Float32Stamped
 

--- a/src/sensors/sub_tf_broadcaster.py
+++ b/src/sensors/sub_tf_broadcaster.py
@@ -3,7 +3,8 @@
 import rospy
 import tf
 import tf2_ros
-from geometry_msgs.msg import QuaternionStamped, TransformStamped, Quaternion, PointStamped, Point
+from geometry_msgs.msg import (QuaternionStamped, TransformStamped, 
+    Quaternion, PointStamped, Point)
 from robosub.msg import Float32Stamped
 
 class Node():

--- a/src/sensors/sub_tf_broadcaster.py
+++ b/src/sensors/sub_tf_broadcaster.py
@@ -3,7 +3,7 @@
 import rospy
 import tf
 import tf2_ros
-from geometry_msgs.msg import QuaternionStamped, TransformStamped
+from geometry_msgs.msg import QuaternionStamped, TransformStamped, Quaternion, PointStamped, Point
 from robosub.msg import Float32Stamped
 
 class Node():
@@ -12,22 +12,38 @@ class Node():
                                     self.orientation_callback)
         self.sub = rospy.Subscriber('depth', Float32Stamped,
                                     self.depth_callback)
+        self.sub = rospy.Subscriber("position/point", PointStamped,
+                                    self.location_callback)
         self.br = tf2_ros.TransformBroadcaster()
         self.child_frame = child_frame
         self.depth = 0.0
+        self.point = Point()
+        self.quaternion = Quaternion()
+        self.update_tf_tree()
 
     def depth_callback(self, msg):
         self.depth = msg.data
+        self.update_tf_tree()
 
     def orientation_callback(self, orientation):
+        self.quaternion = orientation.quaternion
+        self.update_tf_tree()
+
+    def location_callback(self, point):
+        self.point = point.point
+        self.update_tf_tree()
+
+
+
+    def update_tf_tree(self):
         t = TransformStamped()
         t.header.stamp = rospy.Time.now()
         t.header.frame_id = "world"
         t.child_frame_id = self.child_frame
-        t.transform.translation.x = 0.0
-        t.transform.translation.y = 0.0
+        t.transform.translation.x = self.point.x
+        t.transform.translation.y = self.point.y
         t.transform.translation.z = self.depth
-        t.transform.rotation = orientation.quaternion
+        t.transform.rotation = self.quaternion
 
         self.br.sendTransform(t)
 


### PR DESCRIPTION
Previously, both the `localization` node and the `sub_tf_broadcaster` node were publishing frames for `cobalt` to `/tf`. This caused the tf frame to oscillate between the "correct" location and the origin, as seen in #324. Now, `localization` doesn't touch `/tf`, instead letting `sub_tf_broadcaster` compose the frame independently. This should resolve #324.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/326)
<!-- Reviewable:end -->
