### PR TITLE
Make sub_tf_broadcaster required for localization node, generate valid quaternions by default

### DIFF
--- a/launch/localization.launch
+++ b/launch/localization.launch
@@ -3,4 +3,7 @@
 <launch>
     <rosparam command="load" file="$(find robosub)/param/localization.yaml"/>
     <node pkg="robosub" type="localization" name="localization" output="screen"/>
+    <node name="sub_tf_broadcaster" pkg="robosub" type="sub_tf_broadcaster.py" required="true">
+        <param name="child_frame" value="cobalt"/>
+    </node>
 </launch>

--- a/src/sensors/sub_tf_broadcaster.py
+++ b/src/sensors/sub_tf_broadcaster.py
@@ -19,7 +19,7 @@ class Node():
         self.child_frame = child_frame
         self.depth = 0.0
         self.point = Point()
-        self.quaternion = Quaternion()
+        self.quaternion = Quaternion(0, 0, 0, 1)
         self.update_tf_tree()
 
     def depth_callback(self, msg):


### PR DESCRIPTION
For ease-of-use (and a higher degree of abstraction), the localization data would be best accessed via the TF tree. As such, the node broadcasting localization data onto the TF tree should be required for the localization node's launch file.

Moreover, Python instantiates `Quaternion` objects without valid dimensions by default, causing TF to complain if frames are broadcasted with invalid orientation data. This PR specifies a valid "default" quaternion for the `sub_tf_broadcaster` node to use prior to receiving valid orientation data from elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/332)
<!-- Reviewable:end -->
