### PR TITLE
Make sub_tf_broadcaster non-required for rviz.launch. Fixes #336.

### DIFF
--- a/launch/rviz.launch
+++ b/launch/rviz.launch
@@ -5,8 +5,5 @@
         <remap from="robot_description" to="cobalt_description"/>
         <remap from="base_link" to="cobalt"/>
     </node>
-    <node name="sub_tf_broadcaster" pkg="robosub" type="sub_tf_broadcaster.py">
-        <param name="child_frame" value="cobalt"/>
-    </node>
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robosub)/rviz/basic.rviz" required="true" />
 </launch>

--- a/launch/rviz.launch
+++ b/launch/rviz.launch
@@ -5,7 +5,7 @@
         <remap from="robot_description" to="cobalt_description"/>
         <remap from="base_link" to="cobalt"/>
     </node>
-    <node name="sub_tf_broadcaster" pkg="robosub" type="sub_tf_broadcaster.py" required="true">
+    <node name="sub_tf_broadcaster" pkg="robosub" type="sub_tf_broadcaster.py">
         <param name="child_frame" value="cobalt"/>
     </node>
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robosub)/rviz/basic.rviz" required="true" />


### PR DESCRIPTION
In #336, it became apparent that having two nodes declare the same child node as "required" is a _Very Bad Thing™️_ 

Because the sub_tf_broadcaster is really only used in the context of the localization system, it shouldn't be listed as required in `rviz.launch`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/337)
<!-- Reviewable:end -->
