### PR TITLE
Corrected control system derivative calculations

### DIFF
--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -48,6 +48,8 @@ namespace robosub
              * Set the previous message queues to empty.
              */
             previous_error[i].clear();
+
+            new_measurement_available[i] = false;
         }
 
         /*

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <deque>
 
 namespace robosub
 {

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -36,7 +36,30 @@ class ControlSystem
      * Defines conversion scale for converting between radians and degrees.
      */
     static constexpr double _PI_OVER_180 = (3.1415 / 180.0);
+
     static constexpr double _180_OVER_PI = (180.0 / 3.14159);
+
+    /*
+     * Define a custom type for storing a state measurement
+     */
+    struct StateMeasurement
+    {
+        StateMeasurement(const ros::Time _time, const double _val) :
+            time(_time),
+            val(_val)
+        {
+        }
+
+        /*
+         * The time at which the measurement was taken.
+         */
+        const ros::Time time;
+
+        /*
+         * The value of the measurement
+         */
+        const double val;
+    };
 
 public:
     ControlSystem();
@@ -141,10 +164,14 @@ private:
     int num_thrusters;
 
     /*
+     * Boolean vector indicating that new state measurements are available.
+     */
+    Matrix<bool, 6, 1> new_measurement_available;
+
+    /*
      * The previous errors calculated.
      */
-    std::deque<Vector6d> previous_error;
-    std::deque<ros::Time> previous_error_times;
+    Matrix<std::deque<StateMeasurement>, 6, 1> previous_error;
 };
 }
 #endif // CONTROL_SYSTEM_H


### PR DESCRIPTION
This change corrects the bug as reported in https://github.com/PalouseRobosub/robosub/issues/330 by adding in a boolean that indicates whether or not new measurements have arrived for a specific state. New errors are stored only if new state information has been received.

Integral information is still updated even if new state information has not been received. Do we want to change this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/349)
<!-- Reviewable:end -->
