### PR TITLE
Removed the BNO from the launch file

### DIFF
--- a/launch/sensors.launch
+++ b/launch/sensors.launch
@@ -1,11 +1,6 @@
 <launch>
     <node name="depth" pkg="rosserial_python" type="serial_node.py" args="/dev/depth" output="screen"/>
-    <node name="bno055_left" pkg="robosub" type="bno055_sensor" output="screen">
-        <rosparam command="load" file="$(find robosub)/param/bno055_left_calibration.yaml"/>
-    </node>
-    <node name="bno055_right" pkg="robosub" type="bno055_sensor" output="screen">
-        <rosparam command="load" file="$(find robosub)/param/bno055_right_calibration.yaml" />
-    </node>
+
     <node name="trax" pkg="robosub" type="trax_sensor" output="screen"/>
 
     <!-- robosub -->


### PR DESCRIPTION
The BNO sensors are no longer on the sub and the BNO nodes will crash after launch because the ports do not exist. This pull request removes the node launch from the launch file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/355)
<!-- Reviewable:end -->
