### PR TITLE
Updated the fisheye calibration script to not refine corners

### DIFF
--- a/src/vision/calibrate.py
+++ b/src/vision/calibrate.py
@@ -102,11 +102,11 @@ if __name__ == '__main__':
     # Write the calculated calibration to a YAML file.
     with open(args.output, 'w') as f:
         data = dict(
-            camera_matrix = K.tolist(),
-            distortion_coefficients = D.reshape((4)).tolist(),
-            size = dict(
-                cols = _img_shape[0],
-                rows = _img_shape[1]
+            camera_matrix=K.tolist(),
+            distortion_coefficients=D.reshape((4)).tolist(),
+            size=dict(
+                cols=_img_shape[0],
+                rows=_img_shape[1]
             )
         )
         yaml.dump(data, f)

--- a/src/vision/calibrate.py
+++ b/src/vision/calibrate.py
@@ -14,9 +14,6 @@ assert cv2.__version__[0] == '3', \
 # Define the internal dimensions of the checker board pattern.
 CHECKERBOARD = (7, 7)
 
-# Pre-define criteria for OpenCV subpix function.
-subpix_criteria = (cv2.TERM_CRITERIA_EPS+cv2.TERM_CRITERIA_MAX_ITER, 30, 0.1)
-
 # Pre-define OpenCV camera calibration flags.
 calibration_flags = cv2.fisheye.CALIB_RECOMPUTE_EXTRINSIC + \
                     cv2.fisheye.CALIB_CHECK_COND + \


### PR DESCRIPTION
CornerSubPix was causes some of the imgpoints arrays to become ill-conditioned (https://en.wikipedia.org/wiki/Condition_number). This is bad and will produce bad calibrations, so the fisheye.calibrate function is designed to throw an error if an ill-conditioned matrix is encountered. To avoid this issue, the CornerSubPix function (which refines positions of the Checkerboard pattern) has been removed. Additionally, a small bug in output file names has been fixed and output has been changed to YAML for easy parameter loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/373)
<!-- Reviewable:end -->
