### PR TITLE
Removed unused outcomes attribute

### DIFF
--- a/src/ai/basic_states.py
+++ b/src/ai/basic_states.py
@@ -179,7 +179,6 @@ class FireTorpedo(smach.State):
                              outcomes=['success'],
                              input_keys=[],
                              output_keys=[])
-        self.outcomes = outcomes
 
 
     def execute(self, user_data):
@@ -202,7 +201,6 @@ class DropMarker(smach.State):
                              outcomes=['success'],
                              input_keys=[],
                              output_keys=[])
-        self.outcomes = outcomes
 
 
     def execute(self, user_data):


### PR DESCRIPTION
Oh python, why do you let these things happen?

I wasn't quite ready for the roulette AI to be merged yet, as I needed to merge in bottom camera undistortion into the simulator first. As such, this bug has snuck into the main repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/374)
<!-- Reviewable:end -->
