### PR TITLE
Force kill nodes on serial write errors.

### DIFF
--- a/src/utility/serial.cpp
+++ b/src/utility/serial.cpp
@@ -105,7 +105,8 @@ namespace rs
             i = ::write(this->m_port_fd, buf, num);
             if (i < 0)
             {
-                ROS_ERROR("serial write error");
+                ROS_FATAL("serial write error");
+                ros::shutdown();
             }
             else
             {


### PR DESCRIPTION
Serial write errors have been the bane of all of our existence whenever the sub goes down. This causes nodes to die as soon as they occur to prevent infinite loops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/382)
<!-- Reviewable:end -->
