### PR TITLE
Increase control_system test timeout

### DIFF
--- a/src/movement/test/control_system.test
+++ b/src/movement/test/control_system.test
@@ -1,5 +1,5 @@
 <launch>
-    <test test-name="test_control_system" pkg="robosub" type="test_control_system" time-limit="120.0" />
+    <test test-name="test_control_system" pkg="robosub" type="test_control_system" time-limit="180.0" />
 
     <rosparam command="load" file="$(find robosub)/param/cobalt.yaml" />
 

--- a/src/movement/test/control_system.test
+++ b/src/movement/test/control_system.test
@@ -1,5 +1,5 @@
 <launch>
-    <test test-name="test_control_system" pkg="robosub" type="test_control_system" time-limit="180.0" />
+    <test test-name="test_control_system" pkg="robosub" type="test_control_system" time-limit="240.0" />
 
     <rosparam command="load" file="$(find robosub)/param/cobalt.yaml" />
 


### PR DESCRIPTION
Related to #360. 

The current time-out for the control system test is a bit too restrictive and is based on real-world time vs simulator time. On systems that have trouble running the simulator close to real-time speed (my R810 is only managing ~0.65x for reasons I'm still investigating), the test is likely to reach the time-out and fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/390)
<!-- Reviewable:end -->
