### PR TITLE
Adds publisher for acceleration values calculated in control system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 firmware/ros_lib
 *.swp
+.vscode/c_cpp_properties.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 firmware/ros_lib
 *.swp
-.vscode/c_cpp_properties.json

--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
     while(ros::ok())
     {
         control_state_pub.publish(control_system->GetControlStatus());
+        accel_pub.publish(control_system->GetAccelerationEstimate());
         if(control_system->isEnabled() && !silence_control_system)
         {
             pub.publish(control_system->CalculateThrusterMessage());
@@ -107,7 +108,6 @@ int main(int argc, char **argv)
         {
             pub.publish(control_system->GetZeroThrusterMessage());
         }
-        accel_pub.publish(control_system->GetAccelerationEstimate());
         ros::spinOnce();
         r.sleep();
     }

--- a/src/movement/control.cpp
+++ b/src/movement/control.cpp
@@ -1,5 +1,6 @@
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/QuaternionStamped.h"
+#include "geometry_msgs/Accel.h"
 #include "movement/control_system.h"
 #include "ros/ros.h"
 #include "std_msgs/Float32.h"
@@ -76,6 +77,9 @@ int main(int argc, char **argv)
 
     ros::Publisher pub = nh.advertise<robosub_msgs::thruster>("thruster", 1);
 
+    ros::Publisher accel_pub = nh.advertise<geometry_msgs::Accel>(
+        "control_acceleration", 1);
+
     rs::ThrottledPublisher<robosub_msgs::control_status>
             control_state_pub(std::string("control_status"), 1, 5);
 
@@ -103,6 +107,7 @@ int main(int argc, char **argv)
         {
             pub.publish(control_system->GetZeroThrusterMessage());
         }
+        accel_pub.publish(control_system->GetAccelerationEstimate());
         ros::spinOnce();
         r.sleep();
     }

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -815,4 +815,8 @@ namespace robosub
             var = x;
         return var;
     }
+
+    geometry_msgs::Vector6d GetAccelerationEstimate(){
+        return this->acceleration_estimate;
+    }
 }

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -60,6 +60,7 @@ namespace robosub
         current_integral = Vector6d::Zero();
         current_derivative = Vector6d::Zero();
         goals = Vector6d::Zero();
+        acceleration_estimate = Vector6d::Zero();
 
         /*
          * Load thruster node settings. A nodehandle reference is not
@@ -819,7 +820,17 @@ namespace robosub
         return var;
     }
 
-    geometry_msgs::Vector6d GetAccelerationEstimate(){
-        return this->acceleration_estimate;
+    geometry_msgs::Accel ControlSystem::GetAccelerationEstimate()
+    {
+        geometry_msgs::Accel msg;
+
+        msg.linear.x = this->acceleration_estimate[0];
+        msg.linear.y = this->acceleration_estimate[1];
+        msg.linear.z = this->acceleration_estimate[2];
+        msg.angular.x = this->acceleration_estimate[3];
+        msg.angular.y = this->acceleration_estimate[4];
+        msg.angular.z = this->acceleration_estimate[5];
+
+        return msg;
     }
 }

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -597,7 +597,6 @@ namespace robosub
         this->acceleration_estimate[4] = m_accel[4];
         this->acceleration_estimate[5] = m_accel[5];
 
-
         /*
          * Convert accelerations to force by multipling by masses.
          */
@@ -826,6 +825,11 @@ namespace robosub
         return var;
     }
 
+    /**
+     * Returns the stored acceleration value calculated by thruster control.
+     *
+     * @return A ROS Accel message (6d) with most recent acceleration values.
+     */
     geometry_msgs::Accel ControlSystem::GetAccelerationEstimate()
     {
         geometry_msgs::Accel msg;

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -590,7 +590,13 @@ namespace robosub
         m_accel += D.cwiseProduct(current_derivative);
 
         //saves the most recent calculated acceleration for publishing
-        this->acceleration_estimate = m_accel;
+        this->acceleration_estimate[0] = m_accel[0];
+        this->acceleration_estimate[1] = m_accel[1];
+        this->acceleration_estimate[2] = m_accel[2];
+        this->acceleration_estimate[3] = m_accel[3];
+        this->acceleration_estimate[4] = m_accel[4];
+        this->acceleration_estimate[5] = m_accel[5];
+
 
         /*
          * Convert accelerations to force by multipling by masses.

--- a/src/movement/control_system.cpp
+++ b/src/movement/control_system.cpp
@@ -588,6 +588,9 @@ namespace robosub
         m_accel += I.cwiseProduct(current_integral);
         m_accel += D.cwiseProduct(current_derivative);
 
+        //saves the most recent calculated acceleration for publishing
+        this->acceleration_estimate = m_accel;
+
         /*
          * Convert accelerations to force by multipling by masses.
          */

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -75,6 +75,10 @@ public:
     robosub_msgs::thruster CalculateThrusterMessage();
     robosub_msgs::thruster GetZeroThrusterMessage();
     robosub_msgs::control_status GetControlStatus();
+
+    /* Provides external access to the private acceleration_estimate variable */
+    geometry_msgs::Vector6 GetAccelerationEstimate();
+
     bool isEnabled();
     void setEnabled(bool enable);
 
@@ -173,6 +177,10 @@ private:
      * The previous errors calculated.
      */
     Matrix<std::deque<StateMeasurement>, 6, 1> previous_error;
+
+    /* This field supports a publisher of the current acceleration. Calculation
+    happens in the CalculateThrusterMessage() function. */
+    geometry_msgs::Vector6 acceleration_estimate;
 };
 }
 #endif // CONTROL_SYSTEM_H

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -9,6 +9,7 @@
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Vector3.h"
 #include "geometry_msgs/QuaternionStamped.h"
+#include "geometry_msgs/Accel.h"
 #include "robosub_msgs/control.h"
 #include "robosub_msgs/control_status.h"
 #include "robosub_msgs/Float32Stamped.h"
@@ -77,7 +78,7 @@ public:
     robosub_msgs::control_status GetControlStatus();
 
     /* Provides external access to the private acceleration_estimate variable */
-    geometry_msgs::Vector6d GetAccelerationEstimate();
+    geometry_msgs::Accel GetAccelerationEstimate();
 
     bool isEnabled();
     void setEnabled(bool enable);
@@ -180,7 +181,7 @@ private:
 
     /* This field supports a publisher of the current acceleration. Calculation
     happens in the CalculateThrusterMessage() function. */
-    geometry_msgs::Vector6d acceleration_estimate;
+    Vector6d acceleration_estimate;
 };
 }
 #endif // CONTROL_SYSTEM_H

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -76,8 +76,6 @@ public:
     robosub_msgs::thruster CalculateThrusterMessage();
     robosub_msgs::thruster GetZeroThrusterMessage();
     robosub_msgs::control_status GetControlStatus();
-
-    /* Provides external access to the private acceleration_estimate variable */
     geometry_msgs::Accel GetAccelerationEstimate();
 
     bool isEnabled();
@@ -179,8 +177,9 @@ private:
      */
     Matrix<std::deque<StateMeasurement>, 6, 1> previous_error;
 
-    /* This field supports a publisher of the current acceleration. Calculation
-    happens in the CalculateThrusterMessage() function. */
+    /*
+     * The previously calculated acceleration exerted on the submarine.
+     */
     Vector6d acceleration_estimate;
 };
 }

--- a/src/movement/control_system.h
+++ b/src/movement/control_system.h
@@ -77,7 +77,7 @@ public:
     robosub_msgs::control_status GetControlStatus();
 
     /* Provides external access to the private acceleration_estimate variable */
-    geometry_msgs::Vector6 GetAccelerationEstimate();
+    geometry_msgs::Vector6d GetAccelerationEstimate();
 
     bool isEnabled();
     void setEnabled(bool enable);
@@ -180,7 +180,7 @@ private:
 
     /* This field supports a publisher of the current acceleration. Calculation
     happens in the CalculateThrusterMessage() function. */
-    geometry_msgs::Vector6 acceleration_estimate;
+    geometry_msgs::Vector6d acceleration_estimate;
 };
 }
 #endif // CONTROL_SYSTEM_H


### PR DESCRIPTION
Pretty much what it says on the tin. 

I added a private Vector6 in the control system which holds the most recently calculated acceleration values.

I added a method to access this field, which transforms it and returns the data as the geometry_msgs::Accel type.

I added a publisher in control.cpp which makes this data available as a topic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/402)
<!-- Reviewable:end -->
