### PR TITLE
Make Roulette wheel AI to use parameters

### DIFF
--- a/param/ai.yaml
+++ b/param/ai.yaml
@@ -49,10 +49,10 @@ ai:
         yaw_error: 2 # yaw error in degrees that will be tolerated
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
-        stabilize_timeout: 15
-        yaw_relative_timeout: 30
-        go_to_depth_timeout: 10
-        locate_object_timeout: 30
-        move_to_pinger_timeout: 120
-        center_downward_camera_timeout: 50
-        target_color_timeout: 45
+        stabilize_timeout_sec: 15
+        yaw_relative_timeout_sec: 30
+        go_to_depth_timeout_sec: 10
+        locate_object_timeout_sec: 30
+        move_to_pinger_timeout_sec: 120
+        center_downward_camera_timeout_sec: 50
+        target_color_timeout_sec: 45

--- a/param/ai.yaml
+++ b/param/ai.yaml
@@ -42,6 +42,11 @@ ai:
         time: 5.5
         yaw_relative: 60
         forward_speed: 4
+    #TODO test blind_gate_task values
+    blind_gate_task:
+        forward_time: 10 # number of seconds to move forward
+        forward_speed: 6.0 # speed to move forward
+        yaw_error: 2 # yaw error in degrees that will be tolerated
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
         stabilize: 15

--- a/param/ai.yaml
+++ b/param/ai.yaml
@@ -49,10 +49,10 @@ ai:
         yaw_error: 2 # yaw error in degrees that will be tolerated
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
-        stabilize: 15
-        yaw_relative: 30
-        go_to_depth: 10
-        locate_object: 30
-        move_to_pinger: 120
-        center_downward_camera: 50
-        target_color: 45
+        stabilize_timeout: 15
+        yaw_relative_timeout: 30
+        go_to_depth_timeout: 10
+        locate_object_timeout: 30
+        move_to_pinger_timeout: 120
+        center_downward_camera_timeout: 50
+        target_color_timeout: 45

--- a/param/ai.yaml
+++ b/param/ai.yaml
@@ -42,8 +42,12 @@ ai:
         time: 5.5
         yaw_relative: 60
         forward_speed: 4
-    #TODO test blind_gate_task values
-    blind_gate_task:
-        forward_time: 10 # number of seconds to move forward
-        forward_speed: 6.0 # speed to move forward
-        yaw_error: 2 # yaw error in degrees that will be tolerated
+# roulette wheel AI variables. They are all time in seconds
+    roulette_wheel:
+        stabilize: 15
+        yaw_relative: 30
+        go_to_depth: 10
+        locate_object: 30
+        move_to_pinger: 120
+        center_downward_camera: 50
+        target_color: 45

--- a/param/ai_pool.yaml
+++ b/param/ai_pool.yaml
@@ -51,10 +51,10 @@ ai:
 
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
-        stabilize: 25
-        yaw_relative: 40
-        go_to_depth: 20
-        locate_object: 40
-        move_to_pinger: 130
-        center_downward_camera: 60
-        target_color: 55
+        stabilize_timeout: 25
+        yaw_relative_timeout: 40
+        go_to_depth_timeout: 20
+        locate_object_timeout: 40
+        move_to_pinger_timeout: 130
+        center_downward_camera_timeout: 60
+        target_color_timeout: 55

--- a/param/ai_pool.yaml
+++ b/param/ai_pool.yaml
@@ -51,10 +51,10 @@ ai:
 
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
-        stabilize_timeout: 25
-        yaw_relative_timeout: 40
-        go_to_depth_timeout: 20
-        locate_object_timeout: 40
-        move_to_pinger_timeout: 130
-        center_downward_camera_timeout: 60
-        target_color_timeout: 55
+        stabilize_timeout_sec: 25
+        yaw_relative_timeout_sec: 40
+        go_to_depth_timeout_sec: 20
+        locate_object_timeout_sec: 40
+        move_to_pinger_timeout_sec: 130
+        center_downward_camera_timeout_sec: 60
+        target_color_timeout_sec: 55

--- a/param/ai_pool.yaml
+++ b/param/ai_pool.yaml
@@ -44,8 +44,12 @@ ai:
         forward_speed: 5
     move_forward_single:
         distanceGoal: 0.007
-    blind_gate_task:
-        forward_time: 25 # number of seconds to move forward
-        forward_speed: 6.0 # speed to move forward
-        yaw_error: 2 # yaw error in degrees that will be tolerated
-
+# roulette wheel AI variables. They are all time in seconds
+    roulette_wheel:
+        stabilize: 25
+        yaw_relative: 40
+        go_to_depth: 20
+        locate_object: 40
+        move_to_pinger: 130
+        center_downward_camera: 60
+        target_color: 55

--- a/param/ai_pool.yaml
+++ b/param/ai_pool.yaml
@@ -44,6 +44,11 @@ ai:
         forward_speed: 5
     move_forward_single:
         distanceGoal: 0.007
+    blind_gate_task:
+        forward_time: 25 # number of seconds to move forward
+        forward_speed: 6.0 # speed to move forward
+        yaw_error: 2 # yaw error in degrees that will be tolerated
+
 # roulette wheel AI variables. They are all time in seconds
     roulette_wheel:
         stabilize: 25

--- a/src/ai/smach_roulette.py
+++ b/src/ai/smach_roulette.py
@@ -14,36 +14,33 @@ class RouletteTask(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=['success', 'fail'])
 
         # Load parameters for timeout in seconds
-        self.stabilize_timeout = \
-                         rospy.get_param("ai/roulette_wheel/stabilize_timeout")
-        self.target_color_timeout = \
-                         rospy.get_param(
-                         "ai/roulette_wheel/target_color_timeout")
-        self.move_to_pinger_timeout = \
-                         rospy.get_param(
-                         "ai/roulette_wheel/move_to_pinger_timeout")
-        self.depth_timeout = \
-                         rospy.get_param(
-                         "ai/roulette_wheel/go_to_depth_timeout")
-        self.stabilize_timeout = \
-                         rospy.get_param("ai/roulette_wheel/stabilize_timeout")
+        self.stabilize_timeout_sec = \
+                rospy.get_param("ai/roulette_wheel/stabilize_timeout_sec")
+        self.target_color_timeout_sec = \
+                rospy.get_param("ai/roulette_wheel/target_color_timeout_sec")
+        self.move_to_pinger_timeout_sec = \
+                rospy.get_param("ai/roulette_wheel/move_to_pinger_timeout_sec")
+        self.depth_timeout_sec = \
+                rospy.get_param("ai/roulette_wheel/go_to_depth_timeout_sec")
+        self.stabilize_timeout_sec = \
+                rospy.get_param("ai/roulette_wheel/stabilize_timeout_sec")
 
         with self:
             # First, dive to a certain depth and search for the pinger.
             smach.StateMachine.add('DIVE_PINGER', GoToDepth(1.0,
-                                  max_duration=self.depth_timeout),
+                                  max_duration=self.depth_timeout_sec),
                     transitions={'success': 'FIND_PINGER',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('FIND_PINGER', MoveToPinger(
-                                  max_duration=self.move_to_pinger_timeout),
+                                  max_duration=self.move_to_pinger_timeout_sec),
                     transitions={'success': 'STABILIZE',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('STABILIZE', Stabilize(
-                                  max_duration=self.stabilize_timeout),
+                                  max_duration=self.stabilize_timeout_sec),
                     transitions={'success': 'LOCATE_ROULETTE',
                                  'fail': 'fail',
                                  'timeout': 'LOCATE_ROULETTE'})
@@ -55,13 +52,13 @@ class RouletteTask(smach.StateMachine):
 
             # Now, dive lower and center above the desired color.
             smach.StateMachine.add('DIVE_TARGET', GoToDepth(3,
-                                  max_duration=self.depth_timeout),
+                                  max_duration=self.depth_timeout_sec),
                     transitions={'success': 'CENTER_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('CENTER_TARGET', TargetColor(Color.GREEN,
-                                  max_duration=self.target_color_timeout),
+                                  max_duration=self.target_color_timeout_sec),
                     transitions={'success': 'DROP_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'DROP_TARGET'})

--- a/src/ai/smach_roulette.py
+++ b/src/ai/smach_roulette.py
@@ -3,8 +3,8 @@ import rospy
 import smach
 import smach_ros
 from start_switch import start_switch
-import roulette_states as roulette_states
-import basic_states as basic_states
+import roulette_states
+import basic_states
 
 class RouletteTask(smach.StateMachine):
     """Main roulette state task."""

--- a/src/ai/smach_roulette.py
+++ b/src/ai/smach_roulette.py
@@ -3,8 +3,8 @@ import rospy
 import smach
 import smach_ros
 from start_switch import start_switch
-from roulette_states import *
-from basic_states import *
+import roulette_states as roulette_states
+import basic_states as basic_states
 
 class RouletteTask(smach.StateMachine):
     """Main roulette state task."""
@@ -27,45 +27,46 @@ class RouletteTask(smach.StateMachine):
 
         with self:
             # First, dive to a certain depth and search for the pinger.
-            smach.StateMachine.add('DIVE_PINGER', GoToDepth(1.0,
+            smach.StateMachine.add('DIVE_PINGER', basic_states.GoToDepth(1.0,
                                   max_duration=self.depth_timeout_sec),
                     transitions={'success': 'FIND_PINGER',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
-            smach.StateMachine.add('FIND_PINGER', MoveToPinger(
+            smach.StateMachine.add('FIND_PINGER', roulette_states.MoveToPinger(
                                   max_duration=self.move_to_pinger_timeout_sec),
                     transitions={'success': 'STABILIZE',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
-            smach.StateMachine.add('STABILIZE', Stabilize(
+            smach.StateMachine.add('STABILIZE', basic_states.Stabilize(
                                   max_duration=self.stabilize_timeout_sec),
                     transitions={'success': 'LOCATE_ROULETTE',
                                  'fail': 'fail',
                                  'timeout': 'LOCATE_ROULETTE'})
 
             # Next, locate the roulette wheel and center above it.
-            smach.StateMachine.add('LOCATE_ROULETTE', CenterAbove(),
+            smach.StateMachine.add('LOCATE_ROULETTE',
+                    roulette_states.CenterAbove(),
                     transitions={'success': 'DIVE_TARGET',
                                  'fail': 'fail'})
 
             # Now, dive lower and center above the desired color.
-            smach.StateMachine.add('DIVE_TARGET', GoToDepth(3,
+            smach.StateMachine.add('DIVE_TARGET', basic_states.GoToDepth(3,
                                   max_duration=self.depth_timeout_sec),
                     transitions={'success': 'CENTER_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
-            smach.StateMachine.add('CENTER_TARGET', TargetColor(Color.GREEN,
+            smach.StateMachine.add('CENTER_TARGET',
+                    roulette_states.TargetColor(roulette_states.Color.GREEN,
                                   max_duration=self.target_color_timeout_sec),
                     transitions={'success': 'DROP_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'DROP_TARGET'})
 
             # Finally, drop the marker.
-            smach.StateMachine.add('DROP_TARGET',
-                    DropMarker(),
+            smach.StateMachine.add('DROP_TARGET', basic_states.DropMarker(),
                     transitions={'success': 'success'})
 
 if __name__ == '__main__':

--- a/src/ai/smach_roulette.py
+++ b/src/ai/smach_roulette.py
@@ -14,30 +14,36 @@ class RouletteTask(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=['success', 'fail'])
 
         # Load parameters for timeout in seconds
-        self.stabilize_time = rospy.get_param("ai/roulette_wheel/stabilize")
-        self.target_color_time = \
-                         rospy.get_param("ai/roulette_wheel/target_color")
-        self.move_to_pinger_time = \
-                         rospy.get_param("ai/roulette_wheel/move_to_pinger")
-        self.depth_time = rospy.get_param("ai/roulette_wheel/go_to_depth")
-        self.stabilize_time = rospy.get_param("ai/roulette_wheel/stabilize")
+        self.stabilize_timeout = \
+                         rospy.get_param("ai/roulette_wheel/stabilize_timeout")
+        self.target_color_timeout = \
+                         rospy.get_param(
+                         "ai/roulette_wheel/target_color_timeout")
+        self.move_to_pinger_timeout = \
+                         rospy.get_param(
+                         "ai/roulette_wheel/move_to_pinger_timeout")
+        self.depth_timeout = \
+                         rospy.get_param(
+                         "ai/roulette_wheel/go_to_depth_timeout")
+        self.stabilize_timeout = \
+                         rospy.get_param("ai/roulette_wheel/stabilize_timeout")
 
         with self:
             # First, dive to a certain depth and search for the pinger.
             smach.StateMachine.add('DIVE_PINGER', GoToDepth(1.0,
-                                  max_duration=self.depth_time),
+                                  max_duration=self.depth_timeout),
                     transitions={'success': 'FIND_PINGER',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('FIND_PINGER', MoveToPinger(
-                                  max_duration=self.move_to_pinger_time),
+                                  max_duration=self.move_to_pinger_timeout),
                     transitions={'success': 'STABILIZE',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('STABILIZE', Stabilize(
-                                  max_duration=self.stabilize_time),
+                                  max_duration=self.stabilize_timeout),
                     transitions={'success': 'LOCATE_ROULETTE',
                                  'fail': 'fail',
                                  'timeout': 'LOCATE_ROULETTE'})
@@ -49,13 +55,13 @@ class RouletteTask(smach.StateMachine):
 
             # Now, dive lower and center above the desired color.
             smach.StateMachine.add('DIVE_TARGET', GoToDepth(3,
-                                  max_duration=self.depth_time),
+                                  max_duration=self.depth_timeout),
                     transitions={'success': 'CENTER_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'fail'})
 
             smach.StateMachine.add('CENTER_TARGET', TargetColor(Color.GREEN,
-                                  max_duration=self.target_color_time),
+                                  max_duration=self.target_color_timeout),
                     transitions={'success': 'DROP_TARGET',
                                  'fail': 'fail',
                                  'timeout': 'DROP_TARGET'})


### PR DESCRIPTION
Due to recent tests of roulette wheel AI, it is found that default timeout parameters are not good for real world. This PR makes AI to use loaded parameters for timeouts. Summary:

- Adds parameters for simulator into `ai.yaml` for timeouts

- Adds parameters to real world `ai_pool.yml` for timeouts

- Changes AI code to use parameters for timeouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub/414)
<!-- Reviewable:end -->
